### PR TITLE
Add shortcut functions

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -185,3 +185,17 @@ Result:
 
 .. |inquirer theme| image:: images/inquirer_theme.gif
   :alt: Example of theme (GreenPassion)
+
+Shortcut functions
+------------------
+
+For one-off prompts, you can use the shortcut functions.
+
+.. code-block:: python
+
+      text = inquirer.text(message="Enter your username")
+      password = inquirer.password(message='Please enter your password'),
+      choice = inquirer.list_input("Public or private?",
+                                    choices=['public', 'private'])
+      correct = inquirer.confirm("This will delete all your current labels and "
+                              "create a new ones. Continue?", default=False)

--- a/examples/shortcuts.py
+++ b/examples/shortcuts.py
@@ -1,18 +1,19 @@
 import os
 import sys
-import re
 sys.path.append(os.path.realpath('.'))
-from pprint import pprint
 
-import inquirer
+import inquirer  # flake8: noqa
 
 text = inquirer.text(message="Enter your username")
 print(text)
 password = inquirer.password(message='Please enter your password'),
 print(password)
-checkbox = inquirer.checkbox(message='Please define your type of project?', choices=['common', 'backend', 'frontend'])
+checkbox = inquirer.checkbox(message='Please define your type of project?',
+                             choices=['common', 'backend', 'frontend'])
 print(checkbox)
-choice = inquirer.list_input("Public or private?", choices=['public', 'private'])
+choice = inquirer.list_input("Public or private?",
+                             choices=['public', 'private'])
 print(choice)
-correct = inquirer.confirm("This will delete all your current labels and create a new ones. Continue?", default=False)
+correct = inquirer.confirm("This will delete all your current labels and "
+                           "create a new ones. Continue?", default=False)
 print(correct)

--- a/examples/shortcuts.py
+++ b/examples/shortcuts.py
@@ -1,0 +1,18 @@
+import os
+import sys
+import re
+sys.path.append(os.path.realpath('.'))
+from pprint import pprint
+
+import inquirer
+
+text = inquirer.text(message="Enter your username")
+print(text)
+password = inquirer.password(message='Please enter your password'),
+print(password)
+checkbox = inquirer.checkbox(message='Please define your type of project?', choices=['common', 'backend', 'frontend'])
+print(checkbox)
+choice = inquirer.list_input("Public or private?", choices=['public', 'private'])
+print(choice)
+correct = inquirer.confirm("This will delete all your current labels and create a new ones. Continue?", default=False)
+print(correct)

--- a/inquirer/__init__.py
+++ b/inquirer/__init__.py
@@ -6,8 +6,10 @@ try:
     from .prompt import prompt
     from .questions import Text, Password, Confirm, List, Checkbox, \
         load_from_dict, load_from_json
+    from .shortcuts import text, password, confirm, list_input, checkbox
 
     __all__ = ['prompt', 'Text', 'Password', 'Confirm', 'List', 'Checkbox',
-               'load_from_list', 'load_from_dict', 'load_from_json']
+               'load_from_list', 'load_from_dict', 'load_from_json',
+               'text', 'password', 'confirm', 'list_input', 'checkbox']
 except ImportError as e:
     print("An error was found, but returning just with the version: %s" % e)

--- a/inquirer/shortcuts.py
+++ b/inquirer/shortcuts.py
@@ -1,0 +1,32 @@
+from .render.console import ConsoleRender
+from . import questions
+
+
+def text(message, render=None, **kwargs):
+    render = render or ConsoleRender()
+    question = questions.Text(name='', message=message, **kwargs)
+    return render.render(question)
+
+
+def password(message, render=None, **kwargs):
+    render = render or ConsoleRender()
+    question = questions.Password(name='', message=message, **kwargs)
+    return render.render(question)
+
+
+def confirm(message, render=None, **kwargs):
+    render = render or ConsoleRender()
+    question = questions.Confirm(name='', message=message, **kwargs)
+    return render.render(question)
+
+
+def list_input(message, render=None, **kwargs):
+    render = render or ConsoleRender()
+    question = questions.List(name='', message=message, **kwargs)
+    return render.render(question)
+
+
+def checkbox(message, render=None, **kwargs):
+    render = render or ConsoleRender()
+    question = questions.Checkbox(name='', message=message, **kwargs)
+    return render.render(question)

--- a/tests/acceptance/test_shortcuts.py
+++ b/tests/acceptance/test_shortcuts.py
@@ -1,0 +1,36 @@
+import unittest
+import pexpect
+from readchar import key
+
+
+class ShortcutsTest(unittest.TestCase):
+    def setUp(self):
+        self.sut = pexpect.spawn('python examples/shortcuts.py')
+
+    def set_username(self, name='foo'):
+        self.sut.expect("Enter your username", timeout=1)
+        self.sut.sendline(name)
+
+    def set_password(self, password='secret'):
+        self.sut.expect("Please enter your password", timeout=1)
+        self.sut.sendline(password)
+
+    def set_checkbox(self):
+        self.sut.expect('Please define your type of project', timeout=1)
+        self.sut.send(key.ENTER)
+
+    def set_list(self):
+        self.sut.expect('Public or private?', timeout=1)
+        self.sut.send(key.ENTER)
+
+    def set_confirm(self):
+        self.sut.expect('This will delete', timeout=1)
+        self.sut.send('y')
+        self.sut.send(key.ENTER)
+
+    def test_shortcuts(self):
+        self.set_username()
+        self.set_password()
+        self.set_checkbox()
+        self.set_list()
+        self.set_confirm()


### PR DESCRIPTION
Add shortcut functions to allow presenting single inputs like so:

```python
import inquirer

username = inquirer.text('Enter your username')
password = inquirer.password('Enter your password')
```

Not only does this make users' code more concise, it makes it easier to write logic to present different questions based on given inputs.


```python
confirmed = inquirer.confirm('Do you wish to continue?')
if confirmed:
    # ...
else:
    # ...
```

~~I've marked the PR as WIP because it doesn't include docs or tests yet. @magmax Is this something you would consider merging? If so, I'll add docs and tests.~~