### PR TITLE
Fix default selection for checkbox with tagged values in Python 3

### DIFF
--- a/inquirer/questions.py
+++ b/inquirer/questions.py
@@ -63,10 +63,13 @@ class TaggedValue(object):
     def __repr__(self):
         return self.value
 
-    def __cmp__(self, other):
+    def __eq__(self, other):
         if isinstance(other, TaggedValue):
-            return self.value != other.value
-        return self.value != other
+            return self.value == other.value
+        return self.value == other
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
 
 class Question(object):


### PR DESCRIPTION
This change fixes a compatibility issue with Python 3.

Steps to reproduce:
- `python2 checkbox_tagged.py` correctly highlights the defaults
  and returns them when pressing return.
- `python3 checkbox_tagger.py` does not highlight the defaults
  and returns an empty list when pressing return.

Python 3 dropped support of the `__cmp__` method and relies on
`__eq__` instead (which also works in Python 2). As Python 2 does not
implement a default behavior for `__ne__`, implement that method as
well to avoid unexpected behavior.