### PR TITLE
added support for text-mode inputting of { or } chars

### DIFF
--- a/inquirer/render/console/_text.py
+++ b/inquirer/render/console/_text.py
@@ -30,4 +30,9 @@ class Text(BaseConsoleRender):
         if len(pressed) != 1:
             return
 
-        self.current += pressed
+        if pressed == '{':
+            self.current += '{{'
+        elif pressed == '}':
+            self.current += '}}'
+        else:
+            self.current += pressed


### PR DESCRIPTION
found a bug:  you can't input { or } via text mode, because it immediately tries to format the string, which throws the error `ValueError: Single '{' encountered in format string`

This PR fixes it.