### PR TITLE
Revert "added support for text-mode inputting of { or } chars"

### DIFF
--- a/inquirer/render/console/_text.py
+++ b/inquirer/render/console/_text.py
@@ -30,9 +30,4 @@ class Text(BaseConsoleRender):
         if len(pressed) != 1:
             return
 
-        if pressed == '{':
-            self.current += '{{'
-        elif pressed == '}':
-            self.current += '}}'
-        else:
-            self.current += pressed
+        self.current += pressed


### PR DESCRIPTION
Reverts magmax/python-inquirer#46

This generates an invalid output.