### PR TITLE
Less strict readchar pin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(name='inquirer',
       zip_safe=False,
       install_requires=[
           'blessings == 1.7',
-          'readchar == 2.0.1',
+          'readchar >= 2.0.0',
           'python-editor==1.0.4'
       ],
       )


### PR DESCRIPTION
There's effectually no real changes in 2.0.1 [0]

[0]: https://github.com/magmax/python-readchar/compare/2.0.0..e0edfa32e5f11cb0afad1697e4606e6ce11b92dc