### PR TITLE
add list and checklist length parameter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,7 +74,7 @@ Example:
 List
 ----
 
-Shows a list of choices, and allows the selection of one of them.
+Shows a list of choices, and allows the selection of one of them. Default is to show 13 items.
 
 Example:
 
@@ -86,6 +86,7 @@ Example:
     inquirer.List('size',
                   message="What size do you need?",
                   choices=['Jumbo', 'Large', 'Standard', 'Medium', 'Small', 'Micro'],
+                  length=13
               ),
   ]
   answers = inquirer.prompt(questions)
@@ -98,7 +99,7 @@ List questions can take one extra argument :code:`carousel=False`. If set to tru
 Checkbox
 --------
 
-Shows a list of choices, with multiple selection.
+Shows a list of choices, with multiple selection. Default is to show 13 items.
 
 Example:
 
@@ -110,6 +111,7 @@ Example:
     inquirer.Checkbox('interests',
                       message="What are you interested in?",
                       choices=['Computers', 'Books', 'Science', 'Nature', 'Fantasy', 'History'],
+                      length=13
                       ),
   ]
   answers = inquirer.prompt(questions)

--- a/inquirer/questions.py
+++ b/inquirer/questions.py
@@ -85,7 +85,8 @@ class Question(object):
                  default=None,
                  ignore=False,
                  validate=True,
-                 show_default=False):
+                 show_default=False,
+                 length=13):
         self.name = name
         self._message = message
         self._choices = choices or []
@@ -94,6 +95,7 @@ class Question(object):
         self._validate = validate
         self.answers = {}
         self.show_default = show_default
+        self.length = length
 
     @property
     def ignore(self):

--- a/inquirer/render/console/_checkbox.py
+++ b/inquirer/render/console/_checkbox.py
@@ -34,7 +34,11 @@ class Checkbox(BaseConsoleRender):
         else:
             cchoices = choices
 
-        ending_milestone = max(len(choices) - self.half_options, self.half_options + 1)
+        # Check if length is even or odd
+        if self.MAX_OPTIONS_DISPLAYED_AT_ONCE % 2 == 0:
+            ending_milestone = max(len(choices) - self.half_options, self.half_options + 1)
+        else:
+            ending_milestone = max(len(choices) - self.half_options, self.half_options)
         is_in_beginning = self.current <= self.half_options
         is_in_middle = self.half_options < self.current < ending_milestone
         is_in_end = self.current >= ending_milestone
@@ -52,7 +56,11 @@ class Checkbox(BaseConsoleRender):
                 color = self.theme.Checkbox.unselected_color
 
             selector = ' '
-            end_index = ending_milestone + index - self.half_options - 1
+            # Check if lengthis even or odd
+            if self.MAX_OPTIONS_DISPLAYED_AT_ONCE % 2 == 0:
+                end_index = ending_milestone + index - self.half_options
+            else:
+                end_index = ending_milestone + index - self.half_options - 1
             if (is_in_middle and index == self.half_options) \
                     or (is_in_beginning and index == self.current) \
                     or (is_in_end and end_index == self.current):

--- a/inquirer/render/console/_checkbox.py
+++ b/inquirer/render/console/_checkbox.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import division
 from readchar import key
-from .base import BaseConsoleRender, MAX_OPTIONS_DISPLAYED_AT_ONCE, \
-    half_options
+from .base import BaseConsoleRender
 from inquirer import errors
 
 
@@ -16,35 +15,35 @@ class Checkbox(BaseConsoleRender):
     @property
     def is_long(self):
         choices = self.question.choices or []
-        return len(choices) >= MAX_OPTIONS_DISPLAYED_AT_ONCE
+        return len(choices) >= self.MAX_OPTIONS_DISPLAYED_AT_ONCE
 
     def get_options(self):
         choices = self.question.choices or []
         if self.is_long:
             cmin = 0
-            cmax = MAX_OPTIONS_DISPLAYED_AT_ONCE
+            cmax = self.MAX_OPTIONS_DISPLAYED_AT_ONCE
 
-            if half_options < self.current < len(choices) - half_options:
-                cmin += self.current - half_options
-                cmax += self.current - half_options
-            elif self.current >= len(choices) - half_options:
-                cmin += len(choices) - MAX_OPTIONS_DISPLAYED_AT_ONCE
+            if self.half_options < self.current < len(choices) - self.half_options:
+                cmin += self.current - self.half_options
+                cmax += self.current - self.half_options
+            elif self.current >= len(choices) - self.half_options:
+                cmin += len(choices) - self.MAX_OPTIONS_DISPLAYED_AT_ONCE
                 cmax += len(choices)
 
             cchoices = choices[cmin:cmax]
         else:
             cchoices = choices
 
-        ending_milestone = max(len(choices) - half_options, half_options + 1)
-        is_in_beginning = self.current <= half_options
-        is_in_middle = half_options < self.current < ending_milestone
+        ending_milestone = max(len(choices) - self.half_options, self.half_options + 1)
+        is_in_beginning = self.current <= self.half_options
+        is_in_middle = self.half_options < self.current < ending_milestone
         is_in_end = self.current >= ending_milestone
 
         for index, choice in enumerate(cchoices):
             if (is_in_middle and
-                self.current - half_options + index in self.selection) \
+                self.current - self.half_options + index in self.selection) \
                 or (is_in_beginning and index in self.selection) \
-                or (is_in_end and index + max(len(choices) - MAX_OPTIONS_DISPLAYED_AT_ONCE, 0) in self.selection):  # noqa
+                or (is_in_end and index + max(len(choices) - self.MAX_OPTIONS_DISPLAYED_AT_ONCE, 0) in self.selection):  # noqa
 
                 symbol = self.theme.Checkbox.selected_icon
                 color = self.theme.Checkbox.selected_color
@@ -53,8 +52,8 @@ class Checkbox(BaseConsoleRender):
                 color = self.theme.Checkbox.unselected_color
 
             selector = ' '
-            end_index = ending_milestone + index - half_options - 1
-            if (is_in_middle and index == half_options) \
+            end_index = ending_milestone + index - self.half_options - 1
+            if (is_in_middle and index == self.half_options) \
                     or (is_in_beginning and index == self.current) \
                     or (is_in_end and end_index == self.current):
 

--- a/inquirer/render/console/_list.py
+++ b/inquirer/render/console/_list.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from readchar import key
-from .base import BaseConsoleRender, MAX_OPTIONS_DISPLAYED_AT_ONCE, \
-    half_options
+from .base import BaseConsoleRender
 from inquirer import errors
 
 
@@ -14,33 +13,33 @@ class List(BaseConsoleRender):
     @property
     def is_long(self):
         choices = self.question.choices or []
-        return len(choices) >= MAX_OPTIONS_DISPLAYED_AT_ONCE
+        return len(choices) >= self.MAX_OPTIONS_DISPLAYED_AT_ONCE
 
     def get_options(self):
         choices = self.question.choices or []
         if self.is_long:
             cmin = 0
-            cmax = MAX_OPTIONS_DISPLAYED_AT_ONCE
+            cmax = self.MAX_OPTIONS_DISPLAYED_AT_ONCE
 
-            if half_options < self.current < len(choices) - half_options:
-                cmin += self.current - half_options
-                cmax += self.current - half_options
-            elif self.current >= len(choices) - half_options:
-                cmin += len(choices) - MAX_OPTIONS_DISPLAYED_AT_ONCE
+            if self.half_options < self.current < len(choices) - self.half_options:
+                cmin += self.current - self.half_options
+                cmax += self.current - self.half_options
+            elif self.current >= len(choices) - self.half_options:
+                cmin += len(choices) - self.MAX_OPTIONS_DISPLAYED_AT_ONCE
                 cmax += len(choices)
 
             cchoices = choices[cmin:cmax]
         else:
             cchoices = choices
 
-        ending_milestone = max(len(choices) - half_options, half_options + 1)
-        is_in_beginning = self.current <= half_options
-        is_in_middle = half_options < self.current < ending_milestone
+        ending_milestone = max(len(choices) - self.half_options, self.half_options + 1)
+        is_in_beginning = self.current <= self.half_options
+        is_in_middle = self.half_options < self.current < ending_milestone
         is_in_end = self.current >= ending_milestone
 
         for index, choice in enumerate(cchoices):
-            end_index = ending_milestone + index - half_options - 1
-            if (is_in_middle and index == half_options) \
+            end_index = ending_milestone + index - self.half_options - 1
+            if (is_in_middle and index == self.half_options) \
                     or (is_in_beginning and index == self.current) \
                     or (is_in_end and end_index == self.current):
 

--- a/inquirer/render/console/base.py
+++ b/inquirer/render/console/base.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import print_function
+from math import ceil, floor
 
 from blessings import Terminal
 
@@ -18,7 +19,7 @@ class BaseConsoleRender(object):
         self.show_default = show_default
         # Should be odd number as there is always one question selected
         self.MAX_OPTIONS_DISPLAYED_AT_ONCE = self.question.length
-        self.half_options = int((self.MAX_OPTIONS_DISPLAYED_AT_ONCE - 1) / 2)
+        self.half_options = floor(self.MAX_OPTIONS_DISPLAYED_AT_ONCE / 2)
 
     def get_header(self):
         return self.question.message

--- a/inquirer/render/console/base.py
+++ b/inquirer/render/console/base.py
@@ -4,10 +4,6 @@ from __future__ import print_function
 
 from blessings import Terminal
 
-# Should be odd number as there is always one question selected
-MAX_OPTIONS_DISPLAYED_AT_ONCE = 13
-half_options = int((MAX_OPTIONS_DISPLAYED_AT_ONCE - 1) / 2)
-
 
 class BaseConsoleRender(object):
     title_inline = False
@@ -20,6 +16,9 @@ class BaseConsoleRender(object):
         self.answers = {}
         self.theme = theme
         self.show_default = show_default
+        # Should be odd number as there is always one question selected
+        self.MAX_OPTIONS_DISPLAYED_AT_ONCE = self.question.length
+        self.half_options = int((self.MAX_OPTIONS_DISPLAYED_AT_ONCE - 1) / 2)
 
     def get_header(self):
         return self.question.message


### PR DESCRIPTION
I added some functionality to address #80 

I tested with a script I was using and it seems to work effectively.  I do not have any idea what the side effects to this change might be. 

The biggest change was moving `MAX_OPTIONS_DISPLAYED_AT_ONCE` inside `BaseConsoleRender` so that it could be used as an instance variable. 

I did not do any style updates, so if that is desired I can try to do that in a different commit. 

Current things I did not have time to address:
* Validating length to ensure it is an int
* Functionality to determine if the selected length is longer than the terminal window itself. 