### PR TITLE
Make List Questions Behave As Expected

### DIFF
--- a/inquirer/questions.py
+++ b/inquirer/questions.py
@@ -112,7 +112,7 @@ class Question(object):
         for choice in self._solve(self._choices):
             yield (
                 TaggedValue(*choice)
-                if isinstance(choice, tuple) and len(choice) == 2
+                if isinstance(choice, (tuple, list)) and len(choice) == 2
                 else choice
             )
 


### PR DESCRIPTION
The patch I added allows List-type questions to behave as expected when loaded from a JSON file or when the choices are passed as two-item lists instead of two-tuples