### PR TITLE
Include requirements.txt in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt


### PR DESCRIPTION
noticed this failure, when packaging it in NixOS:
```
  File "setup.py", line 80, in <module>
    install_requires=read_requirements().splitlines(),
  File "setup.py", line 23, in read_requirements
    with open('requirements.txt') as fd:
IOError: [Errno 2] No such file or directory: 'requirements.txt'
```

The sdist is broken right now