### PR TITLE
Add MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,9 @@
+include changes.rst
+include LICENSE
+include Makefile
+include README.rst
+include requirements.txt
+include setup.cfg
+
+recursive-include inquirer/ *
+recursive-include tests/ *


### PR DESCRIPTION
Adds MANIFEST.in. Closes #106 

With the MANIFEST.in added the requirements.txt is also included in the tarball. 
I encountered this issue as I was using `inquirer` as a dependency for a python cli tool. Installing the tool via `brew` on OSX fails, since it depends on a correctly packaged tarball for all dependencies.