### PR TITLE
Fix for Python3.10

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
     runs-on: ${{ matrix.platform }}
 
     steps:

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
     runs-on: ${{ matrix.platform }}
 
     steps:

--- a/inquirer/__init__.py
+++ b/inquirer/__init__.py
@@ -1,39 +1,36 @@
 from __future__ import print_function
 
-try:
-    from .prompt import prompt
-    from .questions import (
-        Text,
-        Editor,
-        Password,
-        Confirm,
-        List,
-        Checkbox,
-        Path,
-        load_from_dict,
-        load_from_json,
-        load_from_list,
-    )
-    from .shortcuts import text, editor, password, confirm, list_input, checkbox
+from .prompt import prompt
+from .questions import (
+    Text,
+    Editor,
+    Password,
+    Confirm,
+    List,
+    Checkbox,
+    Path,
+    load_from_dict,
+    load_from_json,
+    load_from_list,
+)
+from .shortcuts import text, editor, password, confirm, list_input, checkbox
 
-    __all__ = [
-        "prompt",
-        "Text",
-        "Editor",
-        "Password",
-        "Confirm",
-        "List",
-        "Checkbox",
-        "Path",
-        "load_from_list",
-        "load_from_dict",
-        "load_from_json",
-        "text",
-        "editor",
-        "password",
-        "confirm",
-        "list_input",
-        "checkbox",
-    ]
-except ImportError as e:
-    print("An error was found, but returning just with the version: %s" % e)
+__all__ = [
+    "prompt",
+    "Text",
+    "Editor",
+    "Password",
+    "Confirm",
+    "List",
+    "Checkbox",
+    "Path",
+    "load_from_list",
+    "load_from_dict",
+    "load_from_json",
+    "text",
+    "editor",
+    "password",
+    "confirm",
+    "list_input",
+    "checkbox",
+]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,8 +3,8 @@
 flake8==3.8.4
 pexpect==4.8.0
 
-pytest==6.2.2
-pytest-cov==2.11.1
+pytest==6.2.5
+pytest-cov==2.12.1
 mock==4.0.3
 
 python-coveralls==2.9.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-blessed==1.17.6
+blessed==1.19.0
 readchar==2.0.1
 python-editor==1.0.4


### PR DESCRIPTION
Hello, I fixed the problem that appears in Python 3.10. The problem was specifically in the library blessed, or rather it did not correctly determine the version of Python, and caused an exception - https://github.com/jquast/blessed/commit/9fd1f6f1322c3691f70ed3036b68c5eebacdb428#diff-ef31c42ff551912ac1c50d3bdbe64043fa7b470854e682c8e0975a874516a8d9. This issue has been fixed in blessed 1.17.9

I also removed the try except block in the __ init __ .py file because I see no meaning in it. When I first ran the script with the inquirer in Python 3.10, he told me 'module' inquirer 'has no attribute' List, "I didn't understand what the problem was, but it turns out he typed a regular message that says Blessed Python 3.2.3 or higher is needed, although I generally have Python 3.10 worth.