### PR TITLE
Removal EOL Python 3.6

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,13 +14,13 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     runs-on: ${{ matrix.platform }}
 
     steps:
     - uses: actions/checkout@v2.4.0
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v2.3.1
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,10 @@ stages:
 
 language: python
 python:
-  - "3.5"
-  - "3.6"
   - "3.7"
   - "3.8"
-  - "pypy3.5-6.0"
+  - "3.9"
+  - "3.10"
 dist: xenial
 sudo: true
 install:

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 import sys
 import os
 from setuptools import setup, find_packages
@@ -59,10 +58,10 @@ setup(
     cmdclass={"test": PyTest},
     classifiers=[
         "Development Status :: 5 - Production/Stable",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Environment :: Console",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Python 3.6 reaches End Of Life this month. This project now supports 3.10.
Reference: https://www.python.org/dev/peps/pep-0494/