### PR TITLE
CONTRIBUTING.rst link in README broken

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -213,4 +213,4 @@ Licensed under `the MIT license`_.
 .. _@magmax_en: https://twitter.com/magmax_en
 .. _the MIT license: https://opensource.org/licenses/MIT
 .. github-only
-.. _Contributor Guide: https://magmax.org/python-inquirer/contributing.html
+.. _Contributor Guide: CONTRIBUTING.rst


### PR DESCRIPTION
The contributor guide link in the README was broken. The new README contributor guide link now links to https://github.com/magmax/python-inquirer/blob/master/CONTRIBUTING.rst and **not the documentation**.  