### PR TITLE
Adds carousel feature to checkbox.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -124,6 +124,8 @@ Example:
   ]
   answers = inquirer.prompt(questions)
 
+Checkbox questions can take one extra argument :code:`carousel=False`. If set to true, the answers will rotate (back to first when pressing down on last choice, and down to last choice when pressing up on first choice)
+
 |inquirer checkbox|
 
 Path

--- a/examples/checkbox_carousel.py
+++ b/examples/checkbox_carousel.py
@@ -1,0 +1,22 @@
+import os
+import sys
+from pprint import pprint
+
+
+sys.path.append(os.path.realpath("."))
+import inquirer  # noqa
+
+
+questions = [
+    inquirer.Checkbox(
+        "interests",
+        message="What are you interested in?",
+        choices=["Computers", "Books", "Science", "Nature", "Fantasy", "History"],
+        default=["Computers", "Books"],
+        carousel=True,
+    ),
+]
+
+answers = inquirer.prompt(questions)
+
+pprint(answers)

--- a/src/inquirer/questions.py
+++ b/src/inquirer/questions.py
@@ -121,6 +121,11 @@ class List(Question):
 class Checkbox(Question):
     kind = "checkbox"
 
+    def __init__(self, name, message="", choices=None, default=None, ignore=False, validate=True, carousel=False):
+
+        super().__init__(name, message, choices, default, ignore, validate)
+        self.carousel = carousel
+
 
 # Solution for checking valid path based on
 # https://stackoverflow.com/a/34102855/1360532

--- a/src/inquirer/render/console/_checkbox.py
+++ b/src/inquirer/render/console/_checkbox.py
@@ -65,11 +65,18 @@ class Checkbox(BaseConsoleRender):
             yield choice, selector + " " + symbol, color
 
     def process_input(self, pressed):
+        question = self.question
         if pressed == key.UP:
-            self.current = max(0, self.current - 1)
+            if question.carousel and self.current == 0:
+                self.current = len(question.choices) - 1
+            else:
+                self.current = max(0, self.current - 1)
             return
         elif pressed == key.DOWN:
-            self.current = min(len(self.question.choices) - 1, self.current + 1)
+            if question.carousel and self.current == len(question.choices) - 1:
+                self.current = 0
+            else:
+                self.current = min(len(self.question.choices) - 1, self.current + 1)
             return
         elif pressed == key.SPACE:
             if self.current in self.selection:

--- a/tests/acceptance/test_checkbox.py
+++ b/tests/acceptance/test_checkbox.py
@@ -59,6 +59,30 @@ class CheckTest(unittest.TestCase):
 
 
 @unittest.skipUnless(sys.platform.startswith("lin"), "Linux only")
+class CheckCarouselTest(unittest.TestCase):
+    def setUp(self):
+        self.sut = pexpect.spawn("python examples/checkbox_carousel.py")
+        self.sut.expect("Computers.*", timeout=1)
+
+    def test_out_of_bounds_up(self):
+        self.sut.send(key.UP)
+        self.sut.expect("History.*", timeout=1)
+        self.sut.send(key.SPACE)
+        self.sut.send(key.ENTER)
+        self.sut.expect(r"{'interests': \['Computers', 'Books', 'History'\]}.*", timeout=1)  # noqa
+
+    def test_out_of_bounds_down(self):
+        for i in range(6):
+            self.sut.send(key.DOWN)
+            # Not looking at what we expect along the way,
+            # let the last "expect" check that we got the right result
+            self.sut.expect(">.*", timeout=1)
+        self.sut.send(key.SPACE)
+        self.sut.send(key.ENTER)
+        self.sut.expect(r"{'interests': \['Books'\]}.*", timeout=1)  # noqa
+
+
+@unittest.skipUnless(sys.platform.startswith("lin"), "Linux only")
 class CheckWithTaggedValuesTest(unittest.TestCase):
     def setUp(self):
         self.sut = pexpect.spawn("python examples/checkbox_tagged.py")

--- a/tests/integration/console_render/test_checkbox.py
+++ b/tests/integration/console_render/test_checkbox.py
@@ -132,6 +132,32 @@ class CheckboxRenderTest(unittest.TestCase, helper.BaseTestCase):
 
         assert result == ["bazz"]
 
+    def test_move_down_carousel(self):
+        stdin = helper.event_factory(key.DOWN, key.DOWN, key.DOWN, key.DOWN, key.SPACE, key.ENTER)
+        message = "Foo message"
+        variable = "Bar variable"
+        choices = ["foo", "bar", "bazz"]
+
+        question = questions.Checkbox(variable, message, choices=choices, carousel=True)
+
+        sut = ConsoleRender(event_generator=stdin)
+        result = sut.render(question)
+
+        assert result == ["bar"]
+
+    def test_move_up_carousel(self):
+        stdin = helper.event_factory(key.UP, key.SPACE, key.ENTER)
+        message = "Foo message"
+        variable = "Bar variable"
+        choices = ["foo", "bar", "bazz"]
+
+        question = questions.Checkbox(variable, message, choices=choices, carousel=True)
+
+        sut = ConsoleRender(event_generator=stdin)
+        result = sut.render(question)
+
+        assert result == ["bazz"]
+
     def test_ctrl_c_breaks_execution(self):
         stdin_array = [key.CTRL_C]
         stdin = helper.event_factory(*stdin_array)


### PR DESCRIPTION
Hi :) I added the carousel feature to checkbox as requested in #78 and in the same manner as previously done for the list.

More specifically this adds the carousel argument `Checkbox(Question)` class and implements the feature in `Checkbox(BaseConsoleRender).process_input()`. It adds the example script `checkbox_carousel.py` as well as two acceptance and two integration tests to verify moving around works. Last but not least it adds a comment about the feature in the `README.md`.

As far as I can see the full test suite succeeds in Python 3.9 :)