### PR TITLE
Version needed to be updated for pypi to have the latest carousel code for checkbox

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "inquirer"
-version = "2.9.1"
+version = "2.9.2"
 description = "Collection of common interactive command line user interfaces, based on Inquirer.js"
 authors = ["Miguel Ángel García <miguelangel.garcia@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
I would love to use default pip install to just get the latest feature.