### PR TITLE
Allow arrow keys to work on windows

### DIFF
--- a/src/inquirer/events.py
+++ b/src/inquirer/events.py
@@ -1,4 +1,5 @@
 import readchar
+import os
 
 if os.name == 'nt':
     from msvcrt import getch

--- a/src/inquirer/events.py
+++ b/src/inquirer/events.py
@@ -1,5 +1,26 @@
 import readchar
 
+if os.name == 'nt':
+    from msvcrt import getch
+    def winreadkey():
+        keypress = getch()
+        if keypress == b'\xe0':
+            keypress = getch()
+        if keypress == b'H':
+            return readchar.key.UP
+        elif keypress == b'P':
+            return readchar.key.DOWN
+        elif keypress == b'K':
+            return readchar.key.LEFT
+        elif keypress == b'M':
+            return readchar.key.RIGHT
+        elif keypress == b'\r':
+            return readchar.key.ENTER
+        else:
+            return keypress.__str__()
+    readkey = winreadkey
+else:
+    readkey = readchar.readkey
 
 class Event:
     pass

--- a/src/inquirer/events.py
+++ b/src/inquirer/events.py
@@ -1,6 +1,7 @@
 import readchar
 import os
 
+# Workaround for windows arrow keys
 if os.name == 'nt':
     from msvcrt import getch
     def winreadkey():


### PR DESCRIPTION
This is a fix to make the arrow keys work in windows.  You can probably make this better, I haven't submitted a change to a repo before but I've seen some posts from others trying to deal with this.