### PR TITLE
Fix validation fails with brace

### DIFF
--- a/src/inquirer/render/console/base.py
+++ b/src/inquirer/render/console/base.py
@@ -33,4 +33,9 @@ class BaseConsoleRender:
         if error.reason:
             return error.reason
 
-        return f'"{error.value}" is not a valid {self.question.name}.'
+        ret = f'"{error.value}" is not a valid {self.question.name}.'
+        try:
+            ret.format()
+            return ret
+        except (ValueError, KeyError):
+            return f"Entered value is not a valid {self.question.name}."

--- a/tests/integration/console_render/test_text.py
+++ b/tests/integration/console_render/test_text.py
@@ -61,6 +61,22 @@ class TextRenderTest(unittest.TestCase, helper.BaseTestCase):
         self.assertInStdout(message)
         self.assertInStdout('"Invalid" is not a valid foo')
 
+    def test_validation_fails_with_brace(self):
+        stdin_array = [x for x in "{Invalid" + key.ENTER + key.BACKSPACE * 20 + "9999" + key.ENTER]
+        stdin = helper.event_factory(*stdin_array)
+
+        message = "Insert number"
+        variable = "foo"
+        expected = "9999"
+
+        question = questions.Text(variable, validate=lambda _, x: re.match(r"\d+", x), message=message)
+
+        sut = ConsoleRender(event_generator=stdin)
+        result = sut.render(question)
+        self.assertEqual(expected, result)
+        self.assertInStdout(message)
+        self.assertInStdout('Entered value is not a valid foo')
+
     def test_validation_fails_with_custom_message(self):
         stdin_array = [x for x in "Invalid" + key.ENTER + key.BACKSPACE * 20 + "9999" + key.ENTER]
         stdin = helper.event_factory(*stdin_array)


### PR DESCRIPTION
Fix crashes that happens when an invalid input has curly braces
```
[?] Enter float: {90.1
Traceback (most recent call last):
  File "my_app.py", line 74, in <module>
    default=make_default(p)
  File "/usr/local/lib/python3.8/dist-packages/inquirer/prompt.py", line 11, in prompt
    answers[question.name] = render.render(question, answers)
  File "/usr/local/lib/python3.8/dist-packages/inquirer/render/console/__init__.py", line 38, in render
    return self._event_loop(render)
  File "/usr/local/lib/python3.8/dist-packages/inquirer/render/console/__init__.py", line 46, in _event_loop
    self._print_status_bar(render)
  File "/usr/local/lib/python3.8/dist-packages/inquirer/render/console/__init__.py", line 62, in _print_status_bar
    self.render_error(self._previous_error)
  File "/usr/local/lib/python3.8/dist-packages/inquirer/render/console/__init__.py", line 129, in render_error
    self.render_in_bottombar(
  File "/usr/local/lib/python3.8/dist-packages/inquirer/render/console/__init__.py", line 136, in render_in_bottombar
    self.print_str(message)
  File "/usr/local/lib/python3.8/dist-packages/inquirer/render/console/__init__.py", line 164, in print_str
    print(base.format(t=self.terminal, **kwargs), end="\n" if lf else "")
ValueError: expected '}' before end of string
```
