### PR TITLE
fix: possible circular import in render.console subfiles

### DIFF
--- a/src/inquirer/render/console/_path.py
+++ b/src/inquirer/render/console/_path.py
@@ -1,4 +1,4 @@
-from inquirer.render.console import Text
+from inquirer.render.console._text import Text
 
 
 class Path(Text):


### PR DESCRIPTION
inside `inquire.render.console.__init__` when `Text` ist not imported before `Path`, the current implementation would result in a circular import. As it is also better practice and in line with the other files, I changed the import to use the sibling-package instead of relying on the import inti `__init__` 

this came up when playing around with `isort`, now we can sort the `__init__` file