### PR TITLE
re-enable isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
-  # - repo: https://github.com/pycqa/isort
-  #   rev: 5.10.1
-  #   hooks:
-  #     - id: isort
-  #       require_serial: true
-  #       types_or: [cython, pyi, python]
-  #       args: ["--filter-files"]
+  - repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+        require_serial: true
+        types_or: [cython, pyi, python]
+        args: ["--filter-files"]
   - repo: https://github.com/psf/black
     rev: 22.6.0
     hooks:

--- a/src/inquirer/render/console/__init__.py
+++ b/src/inquirer/render/console/__init__.py
@@ -5,13 +5,13 @@ from blessed import Terminal
 from inquirer import errors
 from inquirer import events
 from inquirer import themes
-from inquirer.render.console._text import Text
-from inquirer.render.console._editor import Editor
-from inquirer.render.console._password import Password
-from inquirer.render.console._confirm import Confirm
-from inquirer.render.console._list import List
 from inquirer.render.console._checkbox import Checkbox
+from inquirer.render.console._confirm import Confirm
+from inquirer.render.console._editor import Editor
+from inquirer.render.console._list import List
+from inquirer.render.console._password import Password
 from inquirer.render.console._path import Path
+from inquirer.render.console._text import Text
 
 
 class ConsoleRender:


### PR DESCRIPTION
we should re-enable isort, as it helps greatly in maintaining code-consistensy and prevents stuff like https://github.com/magmax/python-inquirer/pull/149#pullrequestreview-842363722