### PR TITLE
pre-commit: add poetry commands

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,3 +34,8 @@ repos:
     rev: v2.4.1
     hooks:
       - id: prettier
+  - repo: https://github.com/python-poetry/poetry
+    rev: 1.2.0b3
+    hooks:
+      - id: poetry-check
+      - id: poetry-lock


### PR DESCRIPTION
poetry offers pre-commit hoocks to run `poerty lock` and `poetry check`.

This makes a lot of sense to me and would avoid situations like https://github.com/magmax/python-inquirer/pull/206#pullrequestreview-1052907971