### PR TITLE
updates, cleanups and unifications of config files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,5 +7,10 @@ indent_style = space
 indent_size = 4
 max_line_length = 119
 
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
+max_line_length = 119
+
 [Makefile]
 indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,7 @@ insert_final_newline = true
 [*.py]
 indent_style = space
 indent_size = 4
-max_line_length = 79
+max_line_length = 119
 
 [Makefile]
 indent_style = tab

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,7 @@
 # Please see the documentation for all configuration options:
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
+---
 version: 2
 updates:
   - package-ecosystem: pip

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,9 +1,9 @@
----
 # Labels names are important as they are used by Release Drafter to decide
 # regarding where to record them in changelog or if to skip them.
 #
 # The repository labels will be automatically configured using this file and
 # the GitHub Action https://github.com/marketplace/actions/github-labeler.
+---
 - name: breaking
   description: Breaking Changes
   color: bfd4f2

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,3 +1,4 @@
+---
 name: Labeler
 
 on:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+---
 repos:
   - repo: https://github.com/pycqa/isort
     rev: 5.10.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,8 +12,8 @@ repos:
       - id: black
         language_version: python3
         require_serial: true
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 6de8252c035844f1e679f509b5f37340b44d5c39
+  - repo: https://github.com/pycqa/flake8
+    rev: 4.0.1
     hooks:
       - id: flake8
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,6 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.1.0
     hooks:
-      - id: check-yaml
       - id: trailing-whitespace
   - repo: https://github.com/asottile/pyupgrade
     rev: v2.29.1
@@ -32,3 +31,7 @@ repos:
     hooks:
       - id: prettier
         args: [--end-of-line, auto]
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.1.0
+    hooks:
+      - id: check-yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,3 +31,4 @@ repos:
     rev: v2.4.1
     hooks:
       - id: prettier
+        args: [--end-of-line, auto]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.3.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.29.1
+    rev: v2.37.3
     hooks:
       - id: pyupgrade
         args: [--py37-plus]
@@ -24,17 +24,17 @@ repos:
         language_version: python3
 
   - repo: https://github.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 5.0.4
     hooks:
       - id: flake8
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.4.1
+    rev: v2.7.1
     hooks:
       - id: prettier
         args: [--end-of-line, auto]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.3.0
     hooks:
       - id: check-yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,37 +1,39 @@
 ---
 repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.1.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.29.1
+    hooks:
+      - id: pyupgrade
+        args: [--py37-plus]
+
   - repo: https://github.com/pycqa/isort
     rev: 5.10.1
     hooks:
       - id: isort
-        require_serial: true
-        types_or: [cython, pyi, python]
-        args: ["--filter-files"]
+
   - repo: https://github.com/psf/black
     rev: 22.6.0
     hooks:
       - id: black
         language_version: python3
-        require_serial: true
+
   - repo: https://github.com/pycqa/flake8
     rev: 4.0.1
     hooks:
       - id: flake8
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
-    hooks:
-      - id: trailing-whitespace
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v2.29.1
-    hooks:
-      - id: pyupgrade
-        types: [python]
-        args: [--py37-plus]
+
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.4.1
     hooks:
       - id: prettier
         args: [--end-of-line, auto]
+
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.1.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,9 +12,6 @@ repos:
       - id: black
         language_version: python3
         require_serial: true
-        args:
-          - -l
-          - "119"
   - repo: https://gitlab.com/pycqa/flake8
     rev: 6de8252c035844f1e679f509b5f37340b44d5c39
     hooks:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,3 +1,4 @@
+---
 version: 2
 build:
   os: ubuntu-20.04

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,4 @@
+---
 comment: false
 coverage:
   status:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,9 @@ source = ["inquirer", "tests"]
 show_missing = true
 fail_under = 95
 
+[tool.black]
+line-length = 119
+
 [tool.isort]
 profile = "black"
 force_single_line = true


### PR DESCRIPTION
This PR aimes to clean, update and unify the different configurations files, espectially pre-commit related stuff.


### black config

black was the only tool configured from the `.pre-commit-config`, I moved the configuration to the `pyproject.toml`. This should make it more obvious to find.

I also changed the `.editorconfig` to reflect the black line-length for python files.


### flake8 repo

`flake8` has an official GitHub repo, no idea where the GitLab link came from...


### YAML file linting

~I made very good experiences with `yamllint`, so I replaced the `check-yaml` hook with this project, set it up and fixed all the linting warning/errors. This is also helpful for the next point.~ I decided that `yamllint` is not really necicary as prettyer allready handles formating for yaml-files and it would just add another not really needed config file to the root folder

So I just sperated the `chack-yaml` from the rest of the pre-commit/pre-commit hooks and moved it to the back.

I also added corresponding `yaml` settings to the `.editorconfig`


### prettier lineendings

by default `prettier` forces unix-lineendings, even on Windows systems. This is annoying because all yaml-files are edited every time I run `pre-commit -a`. With the `end-of-lines = auto` setting, it uses the platform default.


### pre-commit hook order

I changed the order of the pre-commit hooks. Here is my reasoning:

* having `trailing-whitespace` and `end-of-file-fixer` run first makes it easy to spot this common mistakes. Black would also report them, but this way it is clear what actually causes the problem and leaves `black` free to report actual python related formatting issues.
* `pyupgrade` should run before `isort`, as it might remove/change imports
* `flake8` should run after all other python-related hooks, so it can catch syntax errors they might have introduced (even if very unlikely)
* `prettier` before `yamllint` to also catch possible errors

I also removed a few settings that are the default anyway


### pre-commit autoupdate

I brought all hooks to the latest version