### PR TITLE
three new Labels

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -31,6 +31,9 @@
 - name: enhancement
   description: New feature or request
   color: a2eeef
+- name: examples
+  description: Additons or changes to examples
+  color: 50edb0
 - name: github_actions
   description: Pull requests that update Github_actions code
   color: "000000"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -7,6 +7,9 @@
 - name: breaking
   description: Breaking Changes
   color: bfd4f2
+- name: blocked
+  description: waiting for something else
+  color: cccccc
 - name: bug
   description: Something isn't working
   color: d73a4a

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -61,6 +61,9 @@
 - name: testing
   description: Testing
   color: b1fc6f
+- name: upstream_issue
+  description: This issue is caused by an upstream package
+  color: a9fd3e
 - name: wontfix
   description: This will not be worked on
   color: ffffff

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -16,6 +16,8 @@ categories:
     label: "ci"
   - title: ":books: Documentation"
     label: "documentation"
+  - title: ":mortar_board: Examples"
+    label: "examples"
   - title: ":hammer: Refactoring"
     label: "refactoring"
   - title: ":lipstick: Style"


### PR DESCRIPTION
I only now realised we have a workflow for labels. So here is the addition of three labels.


## upstream_issue

a label to mark issues or PRs that are an upstream problem. Mostly to mark issues that are actually `readchar` problems, but may be usefull for other things


## blocked

a label for PRs that are waiting for something else to be resolved. Tha could be another PR or an update on a dependency.


## examples

a label for changes/issues with the examples. Also a new caregory for the release drafter