### PR TITLE
feat: preprocess choices

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -100,7 +100,11 @@ Example:
   ]
   answers = inquirer.prompt(questions)
 
-List questions can take one extra argument :code:`carousel=False`. If set to true, the answers will rotate (back to first when pressing down on last choice, and down to last choice when pressing up on first choice)
+List questions can take extra arguments
+
+:code:`carousel=False` If set to true, the answers will rotate (back to first when pressing down on last choice, and down to last choice when pressing up on first choice)
+
+:code:`preprocessor=function_or_lambda` This options allows you to set choices with types other than :code:`str`, eg. :code:`dict` so you can store metadata alongside the choices, the function should extract the string representing this choice.
 
 |inquirer list|
 
@@ -124,7 +128,13 @@ Example:
   ]
   answers = inquirer.prompt(questions)
 
-Checkbox questions can take one extra argument :code:`carousel=False`. If set to true, the answers will rotate (back to first when pressing down on last choice, and down to last choice when pressing up on first choice)
+Checkbox questions can take extra arguments
+
+:code:`carousel=False` If set to true, the answers will rotate (back to first when pressing down on last choice, and down to last choice when pressing up on first choice)
+
+:code:`preprocessor=function_or_lambda` This options allows you to set choices with types other than :code:`str`, eg. :code:`dict` so you can store metadata alongside the choices, the function should extract the string representing this choice.
+
+
 
 |inquirer checkbox|
 

--- a/examples/checkbox_preprocessor.py
+++ b/examples/checkbox_preprocessor.py
@@ -1,0 +1,29 @@
+import os
+import sys
+from pprint import pprint
+
+
+sys.path.append(os.path.realpath("."))
+import inquirer  # noqa
+
+
+choices = [
+    {"name": "User01", "id": 1},
+    {"name": "User02", "id": 2},
+    {"name": "User03", "id": 3},
+    {"name": "User04", "id": 4}  
+]
+
+questions = [
+    inquirer.Checkbox(
+        "users",
+        message="Select Users",
+        choices=choices,
+        preprocessor=lambda c: c['name'],
+        default=choices[2:]
+    ),
+]
+
+answers = inquirer.prompt(questions)
+
+pprint(answers)

--- a/src/inquirer/questions.py
+++ b/src/inquirer/questions.py
@@ -7,6 +7,7 @@ import os
 import sys
 
 import inquirer.errors as errors
+from typing import Callable, Any
 
 
 class TaggedValue:
@@ -32,10 +33,11 @@ class TaggedValue:
 class Question:
     kind = "base question"
 
-    def __init__(self, name, message="", choices=None, default=None, ignore=False, validate=True, show_default=False):
+    def __init__(self, name, message="", choices=None, default=None, ignore=False, validate=True, show_default=False, preprocessor: Callable[[Any], str] = None):
         self.name = name
         self._message = message
         self._choices = choices or []
+        self._preprocessor = preprocessor
         self._default = default
         self._ignore = ignore
         self._validate = validate
@@ -112,18 +114,18 @@ class Confirm(Question):
 class List(Question):
     kind = "list"
 
-    def __init__(self, name, message="", choices=None, default=None, ignore=False, validate=True, carousel=False):
+    def __init__(self, name, message="", choices=None, default=None, ignore=False, validate=True, carousel=False, preprocessor = None):
 
-        super().__init__(name, message, choices, default, ignore, validate)
+        super().__init__(name, message, choices, default, ignore, validate, preprocessor=preprocessor)
         self.carousel = carousel
 
 
 class Checkbox(Question):
     kind = "checkbox"
 
-    def __init__(self, name, message="", choices=None, default=None, ignore=False, validate=True, carousel=False):
+    def __init__(self, name, message="", choices=None, default=None, ignore=False, validate=True, carousel=False, preprocessor = None):
 
-        super().__init__(name, message, choices, default, ignore, validate)
+        super().__init__(name, message, choices, default, ignore, validate, preprocessor=preprocessor)
         self.carousel = carousel
 
 

--- a/src/inquirer/render/console/_checkbox.py
+++ b/src/inquirer/render/console/_checkbox.py
@@ -19,6 +19,8 @@ class Checkbox(BaseConsoleRender):
 
     def get_options(self):
         choices = self.question.choices or []
+        if self.question._preprocessor:
+            choices = [self.question._preprocessor(c) for c in choices]
         if self.is_long:
             cmin = 0
             cmax = MAX_OPTIONS_DISPLAYED_AT_ONCE

--- a/src/inquirer/render/console/_list.py
+++ b/src/inquirer/render/console/_list.py
@@ -18,6 +18,8 @@ class List(BaseConsoleRender):
 
     def get_options(self):
         choices = self.question.choices or []
+        if self.question._preprocessor:
+            choices = [self.question._preprocessor(c) for c in choices]
         if self.is_long:
             cmin = 0
             cmax = MAX_OPTIONS_DISPLAYED_AT_ONCE


### PR DESCRIPTION
I Added the ability to pass any variable type in the list of the choices by passing a function into `preprocess` argument in `List` / `Checkbox` so it will extract the label of the choice and it will print it, 
So now you can store metadata alongside the choice.
[Example](https://github.com/thewh1teagle/python-inquirer/blob/feat/choices-preprocess/examples/checkbox_preprocessor.py)

---

### TLDR of discussion below:
There are multiple existing optinons to handle usecases for this: Python standart onjects (_dicts_, ...) can be directly used as choises, thier string representation may not look good usually though. You can pass `(prompt, tag)` tuples as choises. Or you can define a class with a `__repr__` that will be used in the prompt.
So this PR doesn't offer much new functionalaty, only slighly more convenience, while potentially executing arbitrary code.