### PR TITLE
Add "Other..." option for checkbox & list questions

### DIFF
--- a/examples/checkbox_other.py
+++ b/examples/checkbox_other.py
@@ -14,6 +14,7 @@ questions = [
         choices=["Computers", "Books", "Science", "Nature", "Fantasy", "History"],
         default=["Computers", "Books"],
         other=True,
+        carousel=True,
     ),
 ]
 

--- a/examples/checkbox_other.py
+++ b/examples/checkbox_other.py
@@ -1,0 +1,22 @@
+import os
+import sys
+from pprint import pprint
+
+
+sys.path.append(os.path.realpath("."))
+import inquirer  # noqa
+
+
+questions = [
+    inquirer.Checkbox(
+        "interests",
+        message="What are you interested in?",
+        choices=["Computers", "Books", "Science", "Nature", "Fantasy", "History"],
+        default=["Computers", "Books"],
+        other=True,
+    ),
+]
+
+answers = inquirer.prompt(questions)
+
+pprint(answers)

--- a/examples/list_other.py
+++ b/examples/list_other.py
@@ -1,0 +1,18 @@
+import os
+import sys
+from pprint import pprint
+
+
+sys.path.append(os.path.realpath("."))
+import inquirer  # noqa
+
+
+questions = [
+    inquirer.List(
+        "size", message="What size do you need?", choices=["Jumbo", "Large", "Standard"], carousel=True, other=True
+    ),
+]
+
+answers = inquirer.prompt(questions)
+
+pprint(answers)

--- a/src/inquirer/questions.py
+++ b/src/inquirer/questions.py
@@ -46,9 +46,10 @@ class Question:
     ):
         if other:
             choices = choices or []
-            choices.insert(0, GLOBAL_OTHER_CHOICE)
+            choices.append(GLOBAL_OTHER_CHOICE)
 
         self.name = name
+        self._other = other
         self._message = message
         self._choices = choices or []
         self._default = default
@@ -62,6 +63,10 @@ class Question:
             index = self._choices.index(choice)
             return index
         except ValueError:
+            if self._other:
+                self._choices.insert(-1, choice)
+                return len(self._choices) - 2
+
             self._choices.append(choice)
             return len(self._choices) - 1
 

--- a/src/inquirer/questions.py
+++ b/src/inquirer/questions.py
@@ -49,7 +49,6 @@ class Question:
             choices.append(GLOBAL_OTHER_CHOICE)
 
         self.name = name
-        self._other = other
         self._message = message
         self._choices = choices or []
         self._default = default
@@ -57,6 +56,7 @@ class Question:
         self._validate = validate
         self.answers = {}
         self.show_default = show_default
+        self._other = other
 
     def add_choice(self, choice):
         try:

--- a/src/inquirer/questions.py
+++ b/src/inquirer/questions.py
@@ -7,6 +7,7 @@ import os
 import sys
 
 import inquirer.errors as errors
+from inquirer.render.console._other import GLOBAL_OTHER_CHOICE
 
 
 class TaggedValue:
@@ -32,7 +33,21 @@ class TaggedValue:
 class Question:
     kind = "base question"
 
-    def __init__(self, name, message="", choices=None, default=None, ignore=False, validate=True, show_default=False):
+    def __init__(
+        self,
+        name,
+        message="",
+        choices=None,
+        default=None,
+        ignore=False,
+        validate=True,
+        show_default=False,
+        other=False,
+    ):
+        if other:
+            choices = choices or []
+            choices.insert(0, GLOBAL_OTHER_CHOICE)
+
         self.name = name
         self._message = message
         self._choices = choices or []
@@ -41,6 +56,14 @@ class Question:
         self._validate = validate
         self.answers = {}
         self.show_default = show_default
+
+    def add_choice(self, choice):
+        try:
+            index = self._choices.index(choice)
+            return index
+        except ValueError:
+            self._choices.append(choice)
+            return len(self._choices) - 1
 
     @property
     def ignore(self):
@@ -112,18 +135,22 @@ class Confirm(Question):
 class List(Question):
     kind = "list"
 
-    def __init__(self, name, message="", choices=None, default=None, ignore=False, validate=True, carousel=False):
+    def __init__(
+        self, name, message="", choices=None, default=None, ignore=False, validate=True, carousel=False, other=False
+    ):
 
-        super().__init__(name, message, choices, default, ignore, validate)
+        super().__init__(name, message, choices, default, ignore, validate, other=other)
         self.carousel = carousel
 
 
 class Checkbox(Question):
     kind = "checkbox"
 
-    def __init__(self, name, message="", choices=None, default=None, ignore=False, validate=True, carousel=False):
+    def __init__(
+        self, name, message="", choices=None, default=None, ignore=False, validate=True, carousel=False, other=False
+    ):
 
-        super().__init__(name, message, choices, default, ignore, validate)
+        super().__init__(name, message, choices, default, ignore, validate, other=other)
         self.carousel = carousel
 
 

--- a/src/inquirer/questions.py
+++ b/src/inquirer/questions.py
@@ -44,10 +44,6 @@ class Question:
         show_default=False,
         other=False,
     ):
-        if other:
-            choices = choices or []
-            choices.append(GLOBAL_OTHER_CHOICE)
-
         self.name = name
         self._message = message
         self._choices = choices or []
@@ -57,6 +53,9 @@ class Question:
         self.answers = {}
         self.show_default = show_default
         self._other = other
+
+        if self._other:
+            self._choices.append(GLOBAL_OTHER_CHOICE)
 
     def add_choice(self, choice):
         try:

--- a/src/inquirer/render/console/_checkbox.py
+++ b/src/inquirer/render/console/_checkbox.py
@@ -1,6 +1,7 @@
 from readchar import key
 
 from inquirer import errors
+from inquirer.render.console._other import GLOBAL_OTHER_CHOICE
 from inquirer.render.console.base import MAX_OPTIONS_DISPLAYED_AT_ONCE
 from inquirer.render.console.base import BaseConsoleRender
 from inquirer.render.console.base import half_options
@@ -62,6 +63,10 @@ class Checkbox(BaseConsoleRender):
 
                 selector = self.theme.Checkbox.selection_icon
                 color = self.theme.Checkbox.selection_color
+
+            if choice == GLOBAL_OTHER_CHOICE:
+                symbol = "+"
+
             yield choice, selector + " " + symbol, color
 
     def process_input(self, pressed):
@@ -79,7 +84,9 @@ class Checkbox(BaseConsoleRender):
                 self.current = min(len(self.question.choices) - 1, self.current + 1)
             return
         elif pressed == key.SPACE:
-            if self.current in self.selection:
+            if self.question.choices[self.current] == GLOBAL_OTHER_CHOICE:
+                self.other_input()
+            elif self.current in self.selection:
                 self.selection.remove(self.current)
             else:
                 self.selection.append(self.current)
@@ -97,3 +104,16 @@ class Checkbox(BaseConsoleRender):
             raise errors.EndOfInput(result)
         elif pressed == key.CTRL_C:
             raise KeyboardInterrupt()
+
+    def other_input(self):
+        other = super().other_input()
+
+        # Clear the print that inquirer.text made
+        print(self.terminal.move_up + self.terminal.clear_eol, end="")
+
+        if not other:
+            return
+
+        index = self.question.add_choice(other)
+        if index not in self.selection:
+            self.selection.append(index)

--- a/src/inquirer/render/console/_list.py
+++ b/src/inquirer/render/console/_list.py
@@ -1,6 +1,7 @@
 from readchar import key
 
 from inquirer import errors
+from inquirer.render.console._other import GLOBAL_OTHER_CHOICE
 from inquirer.render.console.base import MAX_OPTIONS_DISPLAYED_AT_ONCE
 from inquirer.render.console.base import BaseConsoleRender
 from inquirer.render.console.base import half_options
@@ -47,7 +48,7 @@ class List(BaseConsoleRender):
             ):
 
                 color = self.theme.List.selection_color
-                symbol = self.theme.List.selection_cursor
+                symbol = "+" if choice == GLOBAL_OTHER_CHOICE else self.theme.List.selection_cursor
             else:
                 color = self.theme.List.unselected_color
                 symbol = " "
@@ -69,6 +70,14 @@ class List(BaseConsoleRender):
             return
         if pressed == key.ENTER:
             value = self.question.choices[self.current]
+
+            if value == GLOBAL_OTHER_CHOICE:
+                value = self.other_input()
+                if not value:
+                    # Clear the print inquirer.text made, since the user didn't enter anything
+                    print(self.terminal.move_up + self.terminal.clear_eol, end="")
+                    return
+
             raise errors.EndOfInput(getattr(value, "value", value))
 
         if pressed == key.CTRL_C:

--- a/src/inquirer/render/console/_other.py
+++ b/src/inquirer/render/console/_other.py
@@ -1,0 +1,6 @@
+class OtherChoice:
+    def __str__(self):
+        return "Other..."
+
+
+GLOBAL_OTHER_CHOICE = OtherChoice()

--- a/src/inquirer/render/console/_other.py
+++ b/src/inquirer/render/console/_other.py
@@ -1,6 +1,6 @@
 class OtherChoice:
     def __str__(self):
-        return "Other..."
+        return "Other"
 
 
 GLOBAL_OTHER_CHOICE = OtherChoice()

--- a/src/inquirer/render/console/base.py
+++ b/src/inquirer/render/console/base.py
@@ -1,5 +1,7 @@
 from blessed import Terminal
 
+import inquirer
+
 
 # Should be odd number as there is always one question selected
 MAX_OPTIONS_DISPLAYED_AT_ONCE = 13
@@ -16,6 +18,10 @@ class BaseConsoleRender:
         self.answers = {}
         self.theme = theme
         self.show_default = show_default
+
+    def other_input(self):
+        other = inquirer.text(self.question.message)
+        return other
 
     def get_header(self):
         return self.question.message

--- a/tests/acceptance/test_checkbox.py
+++ b/tests/acceptance/test_checkbox.py
@@ -89,26 +89,32 @@ class CheckOtherTest(unittest.TestCase):
         self.sut.expect("Computers.*", timeout=1)
 
     def test_other_input(self):
+        self.sut.send(key.UP)
+        self.sut.expect(r"\+ Other\.\.\..*", timeout=1)
         self.sut.send(key.SPACE)
+        self.sut.expect(r": ", timeout=1)
         self.sut.send("Hello world")
+        self.sut.expect(r"Hello world.*", timeout=1)
         self.sut.send(key.ENTER)
+        self.sut.expect(r"> X Hello world[\s\S]*\+ Other\.\.\..*", timeout=1)
         self.sut.send(key.ENTER)
-        self.sut.expect(r"{'interests': \['Computers', 'Books', 'Hello world'\]}.*", timeout=1)  # noqa
+        self.sut.expect(r"{'interests': \['Computers', 'Books', 'Hello world'\]}", timeout=1)  # noqa
 
     def test_other_blank_input(self):
+        self.sut.send(key.UP)
+        self.sut.expect(r"\+ Other\.\.\..*", timeout=1)
         self.sut.send(key.SPACE)
-        self.sut.send(key.ENTER)  # blank input
-        self.sut.send(key.SPACE)
-        self.sut.send("Hello world")
+        self.sut.expect(r": ", timeout=1)
+        self.sut.send(key.ENTER) # blank input
+        self.sut.expect(r"> \+ Other\.\.\..*", timeout=1)
         self.sut.send(key.ENTER)
-        self.sut.send(key.ENTER)
-        self.sut.expect(r"{'interests': \['Computers', 'Books', 'Hello world'\]}.*", timeout=1)  # noqa
+        self.sut.expect(r"{'interests': \['Computers', 'Books'\]}", timeout=1)  # noqa
 
     def test_other_select_choice(self):
-        self.sut.send(key.DOWN)
         self.sut.send(key.SPACE)
+        self.sut.expect(r"[^X] Computers.*", timeout=1)
         self.sut.send(key.ENTER)
-        self.sut.expect(r"{'interests': \['Books'\]}.*", timeout=1)  # noqa
+        self.sut.expect(r"{'interests': \['Books'\]}", timeout=1)  # noqa
 
 
 @unittest.skipUnless(sys.platform.startswith("lin"), "Linux only")

--- a/tests/acceptance/test_checkbox.py
+++ b/tests/acceptance/test_checkbox.py
@@ -90,23 +90,23 @@ class CheckOtherTest(unittest.TestCase):
 
     def test_other_input(self):
         self.sut.send(key.UP)
-        self.sut.expect(r"\+ Other\.\.\..*", timeout=1)
+        self.sut.expect(r"\+ Other.*", timeout=1)
         self.sut.send(key.SPACE)
         self.sut.expect(r": ", timeout=1)
         self.sut.send("Hello world")
         self.sut.expect(r"Hello world.*", timeout=1)
         self.sut.send(key.ENTER)
-        self.sut.expect(r"> X Hello world[\s\S]*\+ Other\.\.\..*", timeout=1)
+        self.sut.expect(r"> X Hello world[\s\S]*\+ Other.*", timeout=1)
         self.sut.send(key.ENTER)
         self.sut.expect(r"{'interests': \['Computers', 'Books', 'Hello world'\]}", timeout=1)  # noqa
 
     def test_other_blank_input(self):
         self.sut.send(key.UP)
-        self.sut.expect(r"\+ Other\.\.\..*", timeout=1)
+        self.sut.expect(r"\+ Other.*", timeout=1)
         self.sut.send(key.SPACE)
         self.sut.expect(r": ", timeout=1)
         self.sut.send(key.ENTER)  # blank input
-        self.sut.expect(r"> \+ Other\.\.\..*", timeout=1)
+        self.sut.expect(r"> \+ Other.*", timeout=1)
         self.sut.send(key.ENTER)
         self.sut.expect(r"{'interests': \['Computers', 'Books'\]}", timeout=1)  # noqa
 

--- a/tests/acceptance/test_checkbox.py
+++ b/tests/acceptance/test_checkbox.py
@@ -105,7 +105,7 @@ class CheckOtherTest(unittest.TestCase):
         self.sut.expect(r"\+ Other\.\.\..*", timeout=1)
         self.sut.send(key.SPACE)
         self.sut.expect(r": ", timeout=1)
-        self.sut.send(key.ENTER) # blank input
+        self.sut.send(key.ENTER)  # blank input
         self.sut.expect(r"> \+ Other\.\.\..*", timeout=1)
         self.sut.send(key.ENTER)
         self.sut.expect(r"{'interests': \['Computers', 'Books'\]}", timeout=1)  # noqa

--- a/tests/acceptance/test_checkbox.py
+++ b/tests/acceptance/test_checkbox.py
@@ -83,6 +83,35 @@ class CheckCarouselTest(unittest.TestCase):
 
 
 @unittest.skipUnless(sys.platform.startswith("lin"), "Linux only")
+class CheckOtherTest(unittest.TestCase):
+    def setUp(self):
+        self.sut = pexpect.spawn("python examples/checkbox_other.py")
+        self.sut.expect("Computers.*", timeout=1)
+
+    def test_other_input(self):
+        self.sut.send(key.SPACE)
+        self.sut.send("Hello world")
+        self.sut.send(key.ENTER)
+        self.sut.send(key.ENTER)
+        self.sut.expect(r"{'interests': \['Computers', 'Books', 'Hello world'\]}.*", timeout=1)  # noqa
+
+    def test_other_blank_input(self):
+        self.sut.send(key.SPACE)
+        self.sut.send(key.ENTER)  # blank input
+        self.sut.send(key.SPACE)
+        self.sut.send("Hello world")
+        self.sut.send(key.ENTER)
+        self.sut.send(key.ENTER)
+        self.sut.expect(r"{'interests': \['Computers', 'Books', 'Hello world'\]}.*", timeout=1)  # noqa
+
+    def test_other_select_choice(self):
+        self.sut.send(key.DOWN)
+        self.sut.send(key.SPACE)
+        self.sut.send(key.ENTER)
+        self.sut.expect(r"{'interests': \['Books'\]}.*", timeout=1)  # noqa
+
+
+@unittest.skipUnless(sys.platform.startswith("lin"), "Linux only")
 class CheckWithTaggedValuesTest(unittest.TestCase):
     def setUp(self):
         self.sut = pexpect.spawn("python examples/checkbox_tagged.py")

--- a/tests/acceptance/test_list.py
+++ b/tests/acceptance/test_list.py
@@ -64,21 +64,30 @@ class CheckOtherTest(unittest.TestCase):
         self.sut.expect("Standard.*", timeout=1)
 
     def test_other_input(self):
+        self.sut.send(key.UP)
+        self.sut.expect(r"\+ Other\.\.\..*", timeout=1)
         self.sut.send(key.ENTER)
+        self.sut.expect(r": ", timeout=1)
         self.sut.send("Hello world")
+        self.sut.expect(r"Hello world", timeout=1)
         self.sut.send(key.ENTER)
         self.sut.expect("{'size': 'Hello world'}.*", timeout=1)
 
     def test_other_blank_input(self):
+        self.sut.send(key.UP)
+        self.sut.expect(r"\+ Other\.\.\..*", timeout=1)
         self.sut.send(key.ENTER)
+        self.sut.expect(r": ", timeout=1)
         self.sut.send(key.ENTER)  # blank input
+        self.sut.expect(r"\+ Other\.\.\..*", timeout=1)
         self.sut.send(key.ENTER)
+        self.sut.expect(r": ", timeout=1)
         self.sut.send("Hello world")
+        self.sut.expect(r"Hello world", timeout=1)
         self.sut.send(key.ENTER)
         self.sut.expect("{'size': 'Hello world'}.*", timeout=1)
 
     def test_other_select_choice(self):
-        self.sut.send(key.DOWN)
         self.sut.send(key.ENTER)
         self.sut.expect("{'size': 'Jumbo'}.*", timeout=1)
 

--- a/tests/acceptance/test_list.py
+++ b/tests/acceptance/test_list.py
@@ -58,6 +58,32 @@ class ListCarouselTest(unittest.TestCase):
 
 
 @unittest.skipUnless(sys.platform.startswith("lin"), "Linux only")
+class CheckOtherTest(unittest.TestCase):
+    def setUp(self):
+        self.sut = pexpect.spawn("python examples/list_other.py")
+        self.sut.expect("Standard.*", timeout=1)
+
+    def test_other_input(self):
+        self.sut.send(key.ENTER)
+        self.sut.send("Hello world")
+        self.sut.send(key.ENTER)
+        self.sut.expect("{'size': 'Hello world'}.*", timeout=1)
+
+    def test_other_blank_input(self):
+        self.sut.send(key.ENTER)
+        self.sut.send(key.ENTER)  # blank input
+        self.sut.send(key.ENTER)
+        self.sut.send("Hello world")
+        self.sut.send(key.ENTER)
+        self.sut.expect("{'size': 'Hello world'}.*", timeout=1)
+
+    def test_other_select_choice(self):
+        self.sut.send(key.DOWN)
+        self.sut.send(key.ENTER)
+        self.sut.expect("{'size': 'Jumbo'}.*", timeout=1)
+
+
+@unittest.skipUnless(sys.platform.startswith("lin"), "Linux only")
 class ListTaggedTest(unittest.TestCase):
     def setUp(self):
         self.sut = pexpect.spawn("python examples/list_tagged.py")

--- a/tests/acceptance/test_list.py
+++ b/tests/acceptance/test_list.py
@@ -65,7 +65,7 @@ class CheckOtherTest(unittest.TestCase):
 
     def test_other_input(self):
         self.sut.send(key.UP)
-        self.sut.expect(r"\+ Other\.\.\..*", timeout=1)
+        self.sut.expect(r"\+ Other.*", timeout=1)
         self.sut.send(key.ENTER)
         self.sut.expect(r": ", timeout=1)
         self.sut.send("Hello world")
@@ -75,11 +75,11 @@ class CheckOtherTest(unittest.TestCase):
 
     def test_other_blank_input(self):
         self.sut.send(key.UP)
-        self.sut.expect(r"\+ Other\.\.\..*", timeout=1)
+        self.sut.expect(r"\+ Other.*", timeout=1)
         self.sut.send(key.ENTER)
         self.sut.expect(r": ", timeout=1)
         self.sut.send(key.ENTER)  # blank input
-        self.sut.expect(r"\+ Other\.\.\..*", timeout=1)
+        self.sut.expect(r"\+ Other.*", timeout=1)
         self.sut.send(key.ENTER)
         self.sut.expect(r": ", timeout=1)
         self.sut.send("Hello world")


### PR DESCRIPTION
This PR adds a feature to checkbox and list questions which allows users to enter custom input. Just need to set `other=True` when creating the question.

https://user-images.githubusercontent.com/14863743/193604405-effc7732-6c69-4e16-9fe0-2ebf7d582f79.mov