### PR TITLE
Add autocompletion for text prompts

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -302,3 +302,16 @@ For one-off prompts, you can use the shortcut functions.
                               "create a new ones. Continue?", default=False)
 
 .. _Examples: examples.html
+
+Autocompletion
+------------------
+
+You can optionally provide an autocompletion function to the ``Text`` question type and the ``Checkbox`` question type's "Other" option (if enabled).
+
+The autocompletion function is called with the current input string (``text``) as the first argument and the number of times the user has pressed TAB as the second argument (``state``). If the user changes their input, ``state`` will reset to 0.
+
+This information can be used to provide completion based on what the user has already input, and/or the number of times the user has pressed TAB, allowing you to cycle through multiple possible completions.
+
+The function should return what to replace the entire current input with as a ``str``. Any other types will be ignored.
+
+.. literalinclude:: ../examples/text_autocomplete.py

--- a/examples/text_autocomplete.py
+++ b/examples/text_autocomplete.py
@@ -6,15 +6,20 @@ from pprint import pprint
 sys.path.append(os.path.realpath("."))
 import inquirer  # noqa
 
+suggestions = ["inquirer", "hello", "world", "foo", "bar", "baz", "qux"]
 
-def autocomplete_fn(_text, _state):
-    return "inquirer"
+
+def autocomplete_fn(_text, state):
+    # Every time the user presses TAB, we'll switch to the next suggestion
+    # The `state` variable contains the index of the current suggestion
+    # We can wrap it around to the first suggestion if we reach the end
+    return suggestions[state % len(suggestions)]
 
 
 questions = [
     inquirer.Text(
         "name",
-        message="Enter the name of this library (Press TAB to autocomplete)",
+        message="Press TAB to cycle through suggestions",
         autocomplete=autocomplete_fn,
     ),
 ]

--- a/examples/text_autocomplete.py
+++ b/examples/text_autocomplete.py
@@ -1,5 +1,4 @@
 import os
-import re
 import sys
 from pprint import pprint
 
@@ -8,13 +7,15 @@ sys.path.append(os.path.realpath("."))
 import inquirer  # noqa
 
 
-def autocomplete_username(_text, _state):
-    return os.getlogin()
+def autocomplete_fn(_text, _state):
+    return "inquirer"
 
 
 questions = [
     inquirer.Text(
-        "name", message="What's your username? (Press TAB to autocomplete)", autocomplete=autocomplete_username
+        "name",
+        message="Enter the name of this library (Press TAB to autocomplete)",
+        autocomplete=autocomplete_fn,
     ),
 ]
 

--- a/examples/text_autocomplete.py
+++ b/examples/text_autocomplete.py
@@ -1,0 +1,23 @@
+import os
+import re
+import sys
+from pprint import pprint
+
+
+sys.path.append(os.path.realpath("."))
+import inquirer  # noqa
+
+
+def autocomplete_username(_text, _state):
+    return os.getlogin()
+
+
+questions = [
+    inquirer.Text(
+        "name", message="What's your username? (Press TAB to autocomplete)", autocomplete=autocomplete_username
+    ),
+]
+
+answers = inquirer.prompt(questions)
+
+pprint(answers)

--- a/examples/text_autocomplete.py
+++ b/examples/text_autocomplete.py
@@ -1,10 +1,5 @@
-import os
-import sys
-from pprint import pprint
+import inquirer
 
-
-sys.path.append(os.path.realpath("."))
-import inquirer  # noqa
 
 suggestions = ["inquirer", "hello", "world", "foo", "bar", "baz", "qux"]
 
@@ -26,4 +21,4 @@ questions = [
 
 answers = inquirer.prompt(questions)
 
-pprint(answers)
+print(answers)

--- a/src/inquirer/questions.py
+++ b/src/inquirer/questions.py
@@ -141,7 +141,16 @@ class List(Question):
     kind = "list"
 
     def __init__(
-        self, name, message="", choices=None, default=None, ignore=False, validate=True, carousel=False, other=False, autocomplete=None
+        self,
+        name,
+        message="",
+        choices=None,
+        default=None,
+        ignore=False,
+        validate=True,
+        carousel=False,
+        other=False,
+        autocomplete=None,
     ):
 
         super().__init__(name, message, choices, default, ignore, validate, other=other)
@@ -153,7 +162,16 @@ class Checkbox(Question):
     kind = "checkbox"
 
     def __init__(
-        self, name, message="", choices=None, default=None, ignore=False, validate=True, carousel=False, other=False, autocomplete=None
+        self,
+        name,
+        message="",
+        choices=None,
+        default=None,
+        ignore=False,
+        validate=True,
+        carousel=False,
+        other=False,
+        autocomplete=None,
     ):
 
         super().__init__(name, message, choices, default, ignore, validate, other=other)

--- a/src/inquirer/questions.py
+++ b/src/inquirer/questions.py
@@ -141,22 +141,24 @@ class List(Question):
     kind = "list"
 
     def __init__(
-        self, name, message="", choices=None, default=None, ignore=False, validate=True, carousel=False, other=False
+        self, name, message="", choices=None, default=None, ignore=False, validate=True, carousel=False, other=False, autocomplete=None
     ):
 
         super().__init__(name, message, choices, default, ignore, validate, other=other)
         self.carousel = carousel
+        self.autocomplete = autocomplete
 
 
 class Checkbox(Question):
     kind = "checkbox"
 
     def __init__(
-        self, name, message="", choices=None, default=None, ignore=False, validate=True, carousel=False, other=False
+        self, name, message="", choices=None, default=None, ignore=False, validate=True, carousel=False, other=False, autocomplete=None
     ):
 
         super().__init__(name, message, choices, default, ignore, validate, other=other)
         self.carousel = carousel
+        self.autocomplete = autocomplete
 
 
 # Solution for checking valid path based on

--- a/src/inquirer/questions.py
+++ b/src/inquirer/questions.py
@@ -111,10 +111,11 @@ class Question:
 class Text(Question):
     kind = "text"
 
-    def __init__(self, name, message="", default=None, **kwargs):
+    def __init__(self, name, message="", default=None, autocomplete=None, **kwargs):
         super().__init__(
             name, message=message, default=str(default) if default and not callable(default) else default, **kwargs
         )
+        self.autocomplete = autocomplete
 
 
 class Password(Text):

--- a/src/inquirer/render/console/_text.py
+++ b/src/inquirer/render/console/_text.py
@@ -11,6 +11,7 @@ class Text(BaseConsoleRender):
         super().__init__(*args, **kwargs)
         self.current = self.question.default or ""
         self.cursor_offset = 0
+        self._autocomplete_state = 0
 
     def get_current_value(self):
         return self.current + (self.terminal.move_left * self.cursor_offset)
@@ -22,7 +23,11 @@ class Text(BaseConsoleRender):
         if pressed in (key.CR, key.LF, key.ENTER):
             raise errors.EndOfInput(self.current)
 
-        if pressed == key.BACKSPACE:
+        if pressed == key.TAB and self.question.autocomplete:
+            self.current = str(self.question.autocomplete(self.current, self._autocomplete_state))
+            self.cursor_offset = 0
+            self._autocomplete_state += 1
+        elif pressed == key.BACKSPACE:
             if self.current and self.cursor_offset != len(self.current):
                 if self.cursor_offset > 0:
                     n = -self.cursor_offset

--- a/src/inquirer/render/console/base.py
+++ b/src/inquirer/render/console/base.py
@@ -20,7 +20,7 @@ class BaseConsoleRender:
         self.show_default = show_default
 
     def other_input(self):
-        other = inquirer.text(self.question.message)
+        other = inquirer.text(self.question.message, autocomplete=self.question.autocomplete)
         return other
 
     def get_header(self):

--- a/src/inquirer/shortcuts.py
+++ b/src/inquirer/shortcuts.py
@@ -2,9 +2,9 @@ import inquirer.questions as questions
 from inquirer.render.console import ConsoleRender
 
 
-def text(message, render=None, **kwargs):
+def text(message, autocomplete=None, render=None, **kwargs):
     render = render or ConsoleRender()
-    question = questions.Text(name="", message=message, **kwargs)
+    question = questions.Text(name="", message=message, autocomplete=autocomplete, **kwargs)
     return render.render(question)
 
 

--- a/tests/acceptance/test_text.py
+++ b/tests/acceptance/test_text.py
@@ -1,6 +1,7 @@
 import re
 import sys
 import unittest
+import os
 
 import pexpect
 from readchar import key
@@ -41,3 +42,15 @@ class TextTest(unittest.TestCase):
         self.sut.expect_list(
             [re.compile(b"'name': 'foo'"), re.compile(b"'surname': 'bar'"), re.compile(b"'phone': '12345'")], timeout=1
         )
+
+
+@unittest.skipUnless(sys.platform.startswith("lin"), "Linux only")
+class TextAutocompleteTest(unittest.TestCase):
+    def setUp(self):
+        self.sut = pexpect.spawn("python examples/text_autocomplete.py")
+
+    def test_autocomplete(self):
+        self.sut.send("random")
+        self.sut.send(key.TAB)
+        self.sut.send(key.ENTER)
+        self.sut.expect("{'name': '" + os.getlogin() + "'}", timeout=1)

--- a/tests/acceptance/test_text.py
+++ b/tests/acceptance/test_text.py
@@ -1,7 +1,6 @@
 import re
 import sys
 import unittest
-import os
 
 import pexpect
 from readchar import key
@@ -50,7 +49,10 @@ class TextAutocompleteTest(unittest.TestCase):
         self.sut = pexpect.spawn("python examples/text_autocomplete.py")
 
     def test_autocomplete(self):
+        self.sut.expect(": .*", timeout=1)
         self.sut.send("random")
+        self.sut.expect(": random.*", timeout=1)
         self.sut.send(key.TAB)
+        self.sut.expect(": inquirer.*", timeout=1)
         self.sut.send(key.ENTER)
-        self.sut.expect("{'name': '" + os.getlogin() + "'}", timeout=1)
+        self.sut.expect("{'name': 'inquirer'}", timeout=1)

--- a/tests/integration/console_render/test_text.py
+++ b/tests/integration/console_render/test_text.py
@@ -174,6 +174,19 @@ class TextRenderTest(unittest.TestCase, helper.BaseTestCase):
 
         self.assertEqual("abcb", result)
 
+    def test_TAB_with_non_str_autocomplete(self):
+        stdin_array = ["a", key.TAB, "b", key.ENTER]
+        stdin = helper.event_factory(*stdin_array)
+        message = "Foo message"
+        variable = "Bar variable"
+
+        question = questions.Text(variable, message, autocomplete=lambda _text, _state: 1337)
+
+        sut = ConsoleRender(event_generator=stdin)
+        result = sut.render(question)
+
+        self.assertEqual("ab", result)
+
     def test_ctrl_c_breaks_execution(self):
         stdin_array = [key.CTRL_C]
         stdin = helper.event_factory(*stdin_array)

--- a/tests/integration/console_render/test_text.py
+++ b/tests/integration/console_render/test_text.py
@@ -148,6 +148,32 @@ class TextRenderTest(unittest.TestCase, helper.BaseTestCase):
 
         self.assertEqual("abdce", result)
 
+    def test_TAB_without_autocomplete(self):
+        stdin_array = ["a", key.TAB, "b", key.ENTER]
+        stdin = helper.event_factory(*stdin_array)
+        message = "Foo message"
+        variable = "Bar variable"
+
+        question = questions.Text(variable, message)
+
+        sut = ConsoleRender(event_generator=stdin)
+        result = sut.render(question)
+
+        self.assertEqual("a\tb", result)
+
+    def test_TAB_with_autocomplete(self):
+        stdin_array = ["a", key.TAB, "b", key.ENTER]
+        stdin = helper.event_factory(*stdin_array)
+        message = "Foo message"
+        variable = "Bar variable"
+
+        question = questions.Text(variable, message, autocomplete=lambda _text, _state: "abc")
+
+        sut = ConsoleRender(event_generator=stdin)
+        result = sut.render(question)
+
+        self.assertEqual("abcb", result)
+
     def test_ctrl_c_breaks_execution(self):
         stdin_array = [key.CTRL_C]
         stdin = helper.event_factory(*stdin_array)

--- a/tests/integration/console_render/test_text.py
+++ b/tests/integration/console_render/test_text.py
@@ -187,6 +187,41 @@ class TextRenderTest(unittest.TestCase, helper.BaseTestCase):
 
         self.assertEqual("ab", result)
 
+    def test_TAB_with_autocomplete_cycle(self):
+        stdin_array = ["a", key.TAB, key.TAB, key.TAB, "b", key.TAB, key.ENTER]
+        stdin = helper.event_factory(*stdin_array)
+        message = "Foo message"
+        variable = "Bar variable"
+
+        prev_state_cell = None
+
+        def autocomplete_func(text, state):
+            nonlocal prev_state_cell
+
+            # Swap state memory
+            prev_state = prev_state_cell
+            prev_state_cell = state
+
+            if state == 0:
+                if prev_state is None:
+                    # First call
+                    pass
+                else:
+                    # After we pressed TAB 3 times and then pressed b, then TAB again
+                    # state should be 0 again
+                    assert prev_state == 2
+                    return "it worked"
+            else:
+                assert state == prev_state + 1
+            return text
+
+        question = questions.Text(variable, message, autocomplete=autocomplete_func)
+
+        sut = ConsoleRender(event_generator=stdin)
+        result = sut.render(question)
+
+        self.assertEqual("it worked", result)
+
     def test_ctrl_c_breaks_execution(self):
         stdin_array = [key.CTRL_C]
         stdin = helper.event_factory(*stdin_array)


### PR DESCRIPTION
(Branches off of #256)

This adds the ability to add an autocompletion function to `Text` prompts. The autocompletion function has similar semantics as `readline.set_completer`. Pressing TAB will call the autocompletion function and set the current text to whatever it returns.