### PR TITLE
refactor: change default checkboxes

### DIFF
--- a/src/inquirer/themes.py
+++ b/src/inquirer/themes.py
@@ -89,10 +89,10 @@ class Default(Theme):
         self.Editor.opening_prompt_color = term.bright_black
         self.Checkbox.selection_color = term.blue
         self.Checkbox.selection_icon = ">"
-        self.Checkbox.selected_icon = "X"
+        self.Checkbox.selected_icon = "[X]"
         self.Checkbox.selected_color = term.yellow + term.bold
         self.Checkbox.unselected_color = term.normal
-        self.Checkbox.unselected_icon = "o"
+        self.Checkbox.unselected_icon = "[ ]"
         self.List.selection_color = term.blue
         self.List.selection_cursor = ">"
         self.List.unselected_color = term.normal

--- a/tests/acceptance/test_checkbox.py
+++ b/tests/acceptance/test_checkbox.py
@@ -1,8 +1,11 @@
 import sys
 import unittest
+from re import escape
 
 import pexpect
 from readchar import key
+
+from inquirer.themes import Default as Theme
 
 
 @unittest.skipUnless(sys.platform.startswith("lin"), "Linux only")
@@ -85,6 +88,7 @@ class CheckCarouselTest(unittest.TestCase):
 @unittest.skipUnless(sys.platform.startswith("lin"), "Linux only")
 class CheckOtherTest(unittest.TestCase):
     def setUp(self):
+        self.theme = Theme()
         self.sut = pexpect.spawn("python examples/checkbox_other.py")
         self.sut.expect("Computers.*", timeout=1)
 
@@ -96,7 +100,7 @@ class CheckOtherTest(unittest.TestCase):
         self.sut.send("Hello world")
         self.sut.expect(r"Hello world.*", timeout=1)
         self.sut.send(key.ENTER)
-        self.sut.expect(r"> X Hello world[\s\S]*\+ Other.*", timeout=1)
+        self.sut.expect(rf"> {escape(self.theme.Checkbox.selected_icon)} Hello world[\s\S]*\+ Other.*", timeout=1)
         self.sut.send(key.ENTER)
         self.sut.expect(r"{'interests': \['Computers', 'Books', 'Hello world'\]}", timeout=1)  # noqa
 
@@ -112,7 +116,7 @@ class CheckOtherTest(unittest.TestCase):
 
     def test_other_select_choice(self):
         self.sut.send(key.SPACE)
-        self.sut.expect(r"[^X] Computers.*", timeout=1)
+        self.sut.expect(rf"{escape(self.theme.Checkbox.unselected_icon)} Computers.*", timeout=1)
         self.sut.send(key.ENTER)
         self.sut.expect(r"{'interests': \['Books'\]}", timeout=1)  # noqa
 


### PR DESCRIPTION
implements and closes #166. 

Using [ ]/[x] matches GitHubs default checkboxes and also avoids confussion for users that have a different cultural background (#166)