### PR TITLE
Revert "Merge pull request #129 from the-wondersmith/patch-1"

### DIFF
--- a/src/inquirer/questions.py
+++ b/src/inquirer/questions.py
@@ -84,7 +84,7 @@ class Question:
     @property
     def choices_generator(self):
         for choice in self._solve(self._choices):
-            yield (TaggedValue(*choice) if isinstance(choice, (list, tuple, set)) and len(choice) == 2 else choice)
+            yield (TaggedValue(*choice) if isinstance(choice, tuple) and len(choice) == 2 else choice)
 
     @property
     def choices(self):


### PR DESCRIPTION
As discussed on #315, this reverts commit 61df37cc. It was decided that only Tuples are specific enough to implicitly create Tags-Promp-pairs. Build in types List and Set should continue to be usable/printable as they are.

closes #315