### PR TITLE
security: updated gitpython version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -214,7 +214,7 @@ smmap = ">=3.0.1,<6"
 
 [[package]]
 name = "gitpython"
-version = "3.1.29"
+version = "3.1.30"
 description = "GitPython is a python library used to interact with Git repositories"
 category = "dev"
 optional = false
@@ -855,7 +855,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8"
-content-hash = "dd681b8807f124172ca907812f2250d6beeceb2bdf196cb9e63282d794d84963"
+content-hash = "fda1da54dd378e90e1341752a1e070fd86b3129fd6315389633284c5cc971e21"
 
 [metadata.files]
 alabaster = [
@@ -935,8 +935,8 @@ gitdb = [
     {file = "gitdb-4.0.10.tar.gz", hash = "sha256:6eb990b69df4e15bad899ea868dc46572c3f75339735663b81de79b06f17eb9a"},
 ]
 gitpython = [
-    {file = "GitPython-3.1.29-py3-none-any.whl", hash = "sha256:41eea0deec2deea139b459ac03656f0dd28fc4a3387240ec1d3c259a2c47850f"},
-    {file = "GitPython-3.1.29.tar.gz", hash = "sha256:cc36bfc4a3f913e66805a28e84703e419d9c264c1077e537b54f0e1af85dbefd"},
+    {file = "GitPython-3.1.30-py3-none-any.whl", hash = "sha256:cd455b0000615c60e286208ba540271af9fe531fa6a87cc590a7298785ab2882"},
+    {file = "GitPython-3.1.30.tar.gz", hash = "sha256:769c2d83e13f5d938b7688479da374c4e3d49f71549aaf462b646db9602ea6f8"},
 ]
 identify = [
     {file = "identify-2.5.10-py2.py3-none-any.whl", hash = "sha256:fb7c2feaeca6976a3ffa31ec3236a6911fbc51aec9acc111de2aed99f244ade2"},


### PR DESCRIPTION
the old version was flagged as comprimised in the security-workflow

```
+=============================+ 
VULNERABILITIES FOUND
+=============================+ 
-> Vulnerability found in gitpython version 3.1.29
   Vulnerability ID: 52322
   Affected spec: <3.1.30
   ADVISORY: All versions of package gitpython are vulnerable to Remote Code Execution (RCE) due to improper user input validation, which makes it possible to inject a maliciously crafted
   remote URL into the clone command. Exploiting this vulnerability is possible because the library makes external calls to git without sufficient sanitization of input arguments.
   CVE-2022-24439
   For more information, please visit https://pyup.io/v/52322/f17

 Scan was completed. 1 vulnerability was found.

```

updated to secure version `3.1.30`