### PR TITLE
Remove staticdev codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @magmax @staticdev
+* @magmax

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @magmax
+* @magmax @Cube707


### PR DESCRIPTION
Hello @magmax, unfortunately I have be too overloaded with the amount of projects I am maintaining so I would like to step down from python-inquirer. I would recommend to have one more person as codeowner, not sure @Cube707 wants it. In any case, it has been a pleasure to try to contribute a bit here.