### PR TITLE
Refactor and fix multiline text bug

### DIFF
--- a/src/inquirer/render/console/__init__.py
+++ b/src/inquirer/render/console/__init__.py
@@ -132,7 +132,8 @@ class ConsoleRender:
         with self.terminal.location(0, self.height - 2):
             self.clear_eos()
 
-    def render_factory(self, question_type):
+    @staticmethod
+    def render_factory(question_type):
         matrix = {
             "text": Text,
             "editor": Editor,

--- a/src/inquirer/render/console/__init__.py
+++ b/src/inquirer/render/console/__init__.py
@@ -49,7 +49,6 @@ class ConsoleRender:
                 self._print_options(render)
 
                 self._process_input(render)
-                self._force_initial_column()
         except errors.EndOfInput as e:
             self._go_to_end(render)
             return e.selection
@@ -103,8 +102,7 @@ class ConsoleRender:
                 self._previous_error = render.handle_validation_error(e)
 
     def _relocate(self):
-        print(self._position * self.terminal.move_up, end="")
-        self._force_initial_column()
+        print("\r" + self._position * self.terminal.move_up, end="")
         self._position = 0
 
     def _go_to_end(self, render):
@@ -112,9 +110,6 @@ class ConsoleRender:
         if positions > 0:
             print(self._position * self.terminal.move_down, end="")
         self._position = 0
-
-    def _force_initial_column(self):
-        self.print_str("\r")
 
     def render_error(self, message):
         if message:

--- a/src/inquirer/render/console/__init__.py
+++ b/src/inquirer/render/console/__init__.py
@@ -43,7 +43,7 @@ class ConsoleRender:
         try:
             while True:
                 self._relocate()
-                self._print_status_bar(render)
+                self._print_status_bar()
 
                 self._print_header(render)
                 self._print_options(render)
@@ -54,7 +54,7 @@ class ConsoleRender:
             self._go_to_end(render)
             return e.selection
 
-    def _print_status_bar(self, render):
+    def _print_status_bar(self):
         if self._previous_error is None:
             self.clear_bottombar()
             return

--- a/src/inquirer/render/console/__init__.py
+++ b/src/inquirer/render/console/__init__.py
@@ -148,7 +148,7 @@ class ConsoleRender:
         return matrix.get(question_type)
 
     def print_line(self, base, lf=True, **kwargs):
-        self.print_str(base + self.terminal.clear_eol, lf=lf, **kwargs)
+        self.print_str(base, lf=lf, **kwargs)
 
     def print_str(self, base, lf=False, **kwargs):
         msg = base.format(t=self.terminal, **kwargs)

--- a/src/inquirer/render/console/__init__.py
+++ b/src/inquirer/render/console/__init__.py
@@ -77,14 +77,12 @@ class ConsoleRender:
         )
         show_default = render.question.default and render.show_default
         header += default_value if show_default else ""
-        msg_template = (
-            "{t.move_up}{t.clear_eol}{tq.brackets_color}[" "{tq.mark_color}?{tq.brackets_color}]{t.normal} {msg}"
-        )
+        msg_template = "{tq.brackets_color}[{tq.mark_color}?{tq.brackets_color}]{t.normal} {msg}"
 
         # ensure any user input with { or } will not cause a formatting error
         escaped_current_value = str(render.get_current_value()).replace("{", "{{").replace("}", "}}")
         self.print_str(
-            f"\n{msg_template}: {escaped_current_value}",
+            f"{msg_template}: {escaped_current_value}",
             msg=header,
             lf=not render.title_inline,
             tq=self._theme.Question,

--- a/src/inquirer/render/console/__init__.py
+++ b/src/inquirer/render/console/__init__.py
@@ -153,7 +153,7 @@ class ConsoleRender:
         return matrix.get(question_type)
 
     def print_line(self, base, lf=True, **kwargs):
-        self.print_str(base + self.terminal.clear_eol(), lf=lf, **kwargs)
+        self.print_str(base + self.terminal.clear_eol, lf=lf, **kwargs)
 
     def print_str(self, base, lf=False, **kwargs):
         if lf:
@@ -163,7 +163,7 @@ class ConsoleRender:
         sys.stdout.flush()
 
     def clear_eos(self):
-        print(self.terminal.clear_eos(), end="")
+        print(self.terminal.clear_eos, end="")
 
     @property
     def width(self):


### PR DESCRIPTION
commit 1 - [ConsoleRender: remove redundant parameter from _print_status_bar](https://github.com/magmax/python-inquirer/pull/355/commits/ca606d555bcd9f89e0a91ccef7ba64d95ac7e4df):
- unused parameter


commit 2 - [ConsoleRender: remove redundant code in _print_header](https://github.com/magmax/python-inquirer/pull/355/commits/511003b26071a22ffac21e2084e944aa4ce90dbc):
- the `print_header` printed every time new line and then move up once. i don't know what the point of working like this. i tried to do some different uses and it's seems to be pretty redundant. 


commit 3 - [ConsoleRender: remove redundant round brackets](https://github.com/magmax/python-inquirer/pull/355/commits/f6a9ff90de5401e070137f9e9501a24df973da42):
- just aesthetics commit. as for the blessed documentation, it's look like the right way to call ANSI clearing functionality is without round brackets


commit 4 - [ConsoleRender: remove function _force_initial_column](https://github.com/magmax/python-inquirer/pull/355/commits/44ea1c816476e644b408bd629eebe8c82eed8d32):
- the `_force_initial_column` in the end of the event loop seems to be duplicate as after it we call the `_relocate` function who call the `_force_initial_column` again.
- then, remove function `_force_initial_column` as it's just print `\r` and used once on `_relocate_ function. and add in `_relocate` function print to `\r`.


commit 5 - [ConsoleRender: adding handling of lines bigger than terminal width](https://github.com/magmax/python-inquirer/pull/355/commits/13ef9a743c998a490f85634b5d4ebe3ed7cf51a7):
- add clearing eos (end of screen) in relocate.
- remove `clear_eos` on start before event loop (as it happens right after).
- adding calculating of the position in the `print_str` method


commit 6 - [ConsoleRender: remove redundant terminal.clear_eol from print_line](https://github.com/magmax/python-inquirer/pull/355/commits/d1c09a5a25d419bcbeb88d0f1de75da6f4f8351b):
- again, seems to be redundant as if i'm understanding it right all the time the line will be clear, because we are doing clear_eos on the start, and every line is a new line... (eol = end of line)


commit 7 - [ConsoleRender: make render_factory static](https://github.com/magmax/python-inquirer/pull/355/commits/a0667003e638fc8b5f5515db78ae776eaaf8246c):
- unused parameter self