### PR TITLE
Console render refactor print

### DIFF
--- a/src/inquirer/render/console/__init__.py
+++ b/src/inquirer/render/console/__init__.py
@@ -148,7 +148,7 @@ class ConsoleRender:
         self.print_str(msg, lf=lf)
 
     def print_str(self, msg, lf=False):
-        print(msg, end="\n" if lf else "")
+        print("\r" + msg, end="\n" if lf else "")
         sys.stdout.flush()
 
         self._position += math.floor((self.terminal.length(msg) - 1) / self.width)

--- a/src/inquirer/render/console/__init__.py
+++ b/src/inquirer/render/console/__init__.py
@@ -69,17 +69,21 @@ class ConsoleRender:
     def _print_header(self, render):
         header = render.get_header()
 
-        if len(header) > self.width - 6:
-            header = header[: self.width - 9] + "..."
+        header_prefix_template = "{tq.brackets_color}[{tq.mark_color}?{tq.brackets_color}]{t.normal}"
+        header_prefix = header_prefix_template.format(tq=self._theme.Question, t=self.terminal)
+        header = f"{header_prefix} {header}"
 
         default_value = render.question.default
         if default_value and render.show_default:
             header += f" ({self._theme.Question.default_color}{default_value}{self.terminal.normal})"
 
-        msg_prefix_template = "{tq.brackets_color}[{tq.mark_color}?{tq.brackets_color}]{t.normal}"
-        msg_prefix = msg_prefix_template.format(tq=self._theme.Question, t=self.terminal)
-        full_header = f"{msg_prefix} {header}: {str(render.get_current_value())}"
+        header_ending = ": "
+        extra_if_long = "..."
+        maximum_width = self.width - len(header_ending + extra_if_long)
+        if self.terminal.length(header) > maximum_width:
+            header = self.terminal.truncate(header, maximum_width) + extra_if_long
 
+        full_header = f"{header}{header_ending}{str(render.get_current_value())}"
         self.print_str(full_header, lf=not render.title_inline)
 
     def _process_input(self, render):


### PR DESCRIPTION
commit 1 - [ConsoleRender: remove formatting from print_str](https://github.com/magmax/python-inquirer/commit/759964b00e7b511f285ad9c4644d90fdf8ecfd34):
- make the code more readable and comprehensible by removing formatting in the `print_str` function


commit 2 - [ConsoleRender: add \r to print_str to avoid bugs](https://github.com/magmax/python-inquirer/commit/70f0665d2df2a230fd8f2dd7832c1646afe82c72):
- After testing the code following first commit, I noticed a bug where an input can be written too quickly before the re-render process, resulting untracked input and Incorrect output. to resolve this issue, i added `\r` character to `print_str` function. This ensures that the printing occurs at the start of the line, and any untracked input is deleted.


commit 3 - [ConsoleRender: refactor _print_header](https://github.com/magmax/python-inquirer/commit/1cb3d47ffc66bc971625e93ad436ae456510a395):
- refactor `_print_header` function to following basic design patterns (such as assign strings to used parameters)
- trim header using `terminal.truncate` blessed function.
- trim also the default value (it's pretty odd to trim just the question message without the default value, as the default value are not length-limited)