### PR TITLE
fix link to documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ pip install inquirer
 
 ## Documentation
 
-Documentation has been moved to [magmax.org/python-inquirer](https://magmax.org/python-inquirer/).
+Documentation has been moved to [python-inquirer.readthedocs.io](https://python-inquirer.readthedocs.io/).
 
 But here you have a couple of usage examples:
 


### PR DESCRIPTION
previous link to magmax.org/python-inquirer/ gives 404