### PR TITLE
Usage documentation enhancements

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -66,7 +66,7 @@ questions = [
 ]
 ```
 
-The value can be a `function`, with the next sign:
+The value can be a `function`, with the following signature:
 
 ```python
 def get_message(answers): return str()
@@ -89,7 +89,7 @@ If the `message` is too long for the terminal, it will be cut to fit.
 
 Stores the default value to be used as answer. This allow the user just to press `Enter` to use it. It is optional, using `None` if there is no input and no default value.
 
-As in `message`, you can use a new format string or a function with the sign:
+As in `message`, you can use a new format string or a function with the signature:
 
 ```python
 def get_default(answers): return str()
@@ -105,7 +105,7 @@ Remember that it should be a list for `Checkbox` questions.
 
 It contains the list of selectable answers.
 
-Its value can be a `list` of strings, new format style strings or pairs(tuples) or a `function` that returns that list, with the sign:
+Its value can be a `list` of strings, new format style strings or pairs(tuples) or a `function` that returns that list, with the signature:
 
 ```python
 def get_choices(answers): return list(str())
@@ -117,7 +117,7 @@ As before, the `answers` is a `dict` containing the previous answers.
 
 ### validate
 
-Optional attribute that allows the program to check if the answer is valid or not. It requires a `boolean` value or a `function` with the sign:
+Optional attribute that allows the program to check if the answer is valid or not. It requires a `boolean` value or a `function` with the signature:
 
 ```python
 def validate(answers, current): return boolean()
@@ -142,14 +142,14 @@ def validation_function(answers, current):
 
 
 Text('nothing', "Moody question", validate=validation_function)
-Text('age', "How old are you?", validate=lambda _, c: 0 <= c < 120)
+Text('age', "How old are you?", validate=lambda _, c: 0 <= int(c) < 120)
 ```
 
 ### ignore
 
 Questions are statically created and some of them may be optional depending on other answers. This attribute allows to control this by hiding the question.
 
-It's value is `boolean` or a `function` with the sign:
+It's value is `boolean` or a `function` with the signature:
 
 ```python
 def ignore(answers): return boolean()

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -75,10 +75,12 @@ def get_message(answers: dict) -> str:
 Example:
 
 ```python
+from inquirer import text
+
 def get_message(answers):
     return "What's your name?"
 
-Text(name='name', message= get_message)
+text(name='name', message= get_message)
 ```
 
 Where `answers` is the dictionary with previous answers.
@@ -131,7 +133,7 @@ inside the validation function, but be aware that if the validation passes you s
 Example:
 
 ```python
-from inquirer import errors
+from inquirer import errors, text
 import random
 
 def validation_function(answers, current):
@@ -141,8 +143,8 @@ def validation_function(answers, current):
    return True
 
 
-Text('nothing', "Moody question", validate=validation_function)
-Text('age', "How old are you?", validate=lambda _, c: 0 <= int(c) < 120)
+text('nothing', "Moody question", validate=validation_function)
+text('age', "How old are you?", validate=lambda _, c: 0 <= int(c) < 120)
 ```
 
 ### ignore
@@ -160,6 +162,8 @@ where `answers` contains the `dict` of previous answers again.
 Example:
 
 ```python
+import inquirer
+
 questions = [
     inquirer.Text("name", message="What's your name?"),
     inquirer.Text(

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -69,7 +69,7 @@ questions = [
 The value can be a `function`, with the following signature:
 
 ```python
-def get_message(answers): return str()
+def get_message(answers: dict) -> str:
 ```
 
 Example:
@@ -92,7 +92,7 @@ Stores the default value to be used as answer. This allow the user just to press
 As in `message`, you can use a new format string or a function with the signature:
 
 ```python
-def get_default(answers): return str()
+def get_default(answers: dict) -> str():
 ```
 
 Where `answers` is a `dict` containing all previous answers.
@@ -108,7 +108,7 @@ It contains the list of selectable answers.
 Its value can be a `list` of strings, new format style strings or pairs(tuples) or a `function` that returns that list, with the signature:
 
 ```python
-def get_choices(answers): return list(str())
+def get_choices(answers: dict) -> list[str]:
 ```
 
 If any of the list values is a pair, it should be a tuple like: `(label, value)`. Then the `label` will be shown but the `value` will be returned.
@@ -120,7 +120,7 @@ As before, the `answers` is a `dict` containing the previous answers.
 Optional attribute that allows the program to check if the answer is valid or not. It requires a `boolean` value or a `function` with the signature:
 
 ```python
-def validate(answers, current): return boolean()
+def validate(answers: dict, current: str) -> bool:
 ```
 
 Where `answers` is a `dict` with previous answers again and `current` is the current answer.
@@ -152,7 +152,7 @@ Questions are statically created and some of them may be optional depending on o
 It's value is `boolean` or a `function` with the signature:
 
 ```python
-def ignore(answers): return boolean()
+def ignore(answers: dict) -> bool:
 ```
 
 where `answers` contains the `dict` of previous answers again.


### PR DESCRIPTION
- Replaced the term "sign" with "signature"
- Fixed the validation example that would throw an exception due to a mismatch between str and int