### PR TITLE
fix tagged-pairs not printing correctly (regression)

### DIFF
--- a/examples/list_hints.py
+++ b/examples/list_hints.py
@@ -3,9 +3,9 @@ from pprint import pprint
 import inquirer  # noqa
 
 choices_hints = {
-    "Jumbo": "The biggest one we have",
-    "Large": "If you need the extra kick",
     "Standard": "For your every day use",
+    "Large": "If you need the extra kick",
+    "Jumbo": "The biggest one we have",
 }
 
 questions = [

--- a/src/inquirer/questions.py
+++ b/src/inquirer/questions.py
@@ -12,29 +12,29 @@ from inquirer.render.console._other import GLOBAL_OTHER_CHOICE
 
 
 class TaggedValue:
-    def __init__(self, choice):
-        self.label = choice[0]
-        self.tag = choice[1]
-        self._hash = hash(choice)
+    def __init__(self, tag, value):
+        self.tag = tag
+        self.value = value
+        self.tuple = (tag, value)
 
     def __str__(self):
-        return self.label
+        return self.tag
 
     def __repr__(self):
-        return repr(self.tag)
+        return repr(self.value)
 
     def __eq__(self, other):
         if isinstance(other, TaggedValue):
-            return other.tag == self.tag
+            return other.value == self.value
         if isinstance(other, tuple):
-            return other == (self.label, self.tag)
-        return other == self.tag
+            return other == self.tuple
+        return other == self.value
 
     def __ne__(self, other):
         return not self.__eq__(other)
 
     def __hash__(self) -> int:
-        return self._hash
+        return hash(self.tuple)
 
 
 class Question:
@@ -93,7 +93,7 @@ class Question:
     @property
     def choices_generator(self):
         for choice in self._solve(self._choices):
-            yield (TaggedValue(choice) if isinstance(choice, tuple) and len(choice) == 2 else choice)
+            yield (TaggedValue(*choice) if isinstance(choice, tuple) and len(choice) == 2 else choice)
 
     @property
     def choices(self):

--- a/tests/unit/test_question.py
+++ b/tests/unit/test_question.py
@@ -354,16 +354,16 @@ class TestPathQuestion(unittest.TestCase):
 
 def test_tagged_value():
     LABEL = "label"
-    TAG = "l"
-    tp = (LABEL, TAG)
-    tv = questions.TaggedValue(tp)
+    VALUE = "l"
+    tp = (LABEL, VALUE)
+    tv = questions.TaggedValue(*tp)
 
     assert (str(tv) == str(LABEL)) is True
-    assert (repr(tv) == repr(TAG)) is True
+    assert (repr(tv) == repr(VALUE)) is True
     assert (hash(tv) == hash(tp)) is True
 
     assert (tv == tv) is True
     assert (tv != tv) is False
     assert (tv == tp) is True
-    assert (tv == TAG) is True
+    assert (tv == VALUE) is True
     assert (tv == "") is False


### PR DESCRIPTION
when using tagged value pairs, the string representation behaved not as expected

closes #515 