### PR TITLE
fix links missing from 8260f8

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ This will allow a chance to talk it over with the owners and validate your appro
 <!-- github-only -->
 
 [code of conduct]: CODE_OF_CONDUCT.md
-[documentation]: https://magmax.org/python-inquirer/
+[documentation]: https://python-inquirer.readthedocs.io
 [issue tracker]: https://github.com/magmax/python-inquirer/issues
 [mit license]: https://opensource.org/licenses/MIT
 [nox]: https://nox.thea.codes/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "MIT"
 readme = "README.md"
 homepage = "https://github.com/magmax/python-inquirer"
 repository = "https://github.com/magmax/python-inquirer"
-documentation = "https://magmax.org/python-inquirer"
+documentation = "https://python-inquirer.readthedocs.io"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Programming Language :: Python :: 3.8",


### PR DESCRIPTION
Theses links are still pointing to the old documentation. Now changed to read-the-docs

closes #514