### PR TITLE
Adding a "searching" feature to List()

### DIFF
--- a/examples/list_search.py
+++ b/examples/list_search.py
@@ -1,0 +1,18 @@
+import os
+import sys
+from pprint import pprint
+
+
+sys.path.append(os.path.realpath("."))
+import inquirer  # noqa
+
+
+questions = [
+    inquirer.List(
+        "size", message="What size do you need?", choices=["Jumbo", "Large", "Standard"], carousel=True, search=True
+    ),
+]
+
+answers = inquirer.prompt(questions)
+
+pprint(answers)

--- a/src/inquirer/questions.py
+++ b/src/inquirer/questions.py
@@ -159,10 +159,12 @@ class List(Question):
         carousel=False,
         other=False,
         autocomplete=None,
+        search=False
     ):
         super().__init__(name, message, choices, default, ignore, validate, hints=hints, other=other)
         self.carousel = carousel
         self.autocomplete = autocomplete
+        self.search = search
 
 
 class Checkbox(Question):

--- a/src/inquirer/render/console/_list.py
+++ b/src/inquirer/render/console/_list.py
@@ -11,11 +11,18 @@ class List(BaseConsoleRender):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.current = self._current_index()
+        self.input = ""
 
     @property
     def is_long(self):
         choices = self.question.choices or []
         return len(choices) >= MAX_OPTIONS_DISPLAYED_AT_ONCE
+
+    def get_current_value(self):
+        if self.question.search:
+            return self.input
+        else:
+            return ""
 
     def get_hint(self):
         try:
@@ -89,6 +96,16 @@ class List(BaseConsoleRender):
                     return
 
             raise errors.EndOfInput(getattr(value, "value", value))
+
+        if pressed.isprintable():
+            self.input += pressed
+            for choice in self.question.choices:
+                if choice.startswith(self.input):
+                    self.current = self.question.choices.index(choice)
+                    break
+
+        if pressed == chr(127):
+            self.input = self.input[:-1]
 
         if pressed == key.CTRL_C:
             raise KeyboardInterrupt()

--- a/tests/integration/console_render/test_list.py
+++ b/tests/integration/console_render/test_list.py
@@ -132,6 +132,19 @@ class ListRenderTest(unittest.TestCase, helper.BaseTestCase):
         with pytest.raises(KeyboardInterrupt):
             sut.render(question)
 
+    def test_type_char(self):
+        stdin = helper.event_factory('b', 'a', 'z', key.ENTER)
+        message = "Foo message"
+        variable = "Bar variable"
+        choices = ["foo", "bar", "bazz"]
+
+        question = questions.List(variable, message, choices=choices, carousel=True)
+
+        sut = ConsoleRender(event_generator=stdin)
+        result = sut.render(question)
+
+        assert result == "bazz"
+
     def test_first_hint_is_shown(self):
         stdin = helper.event_factory(key.ENTER)
         message = "Foo message"


### PR DESCRIPTION
What this adds:

- While browsing a list, the user can now type the entry he wants to select, instead of using arrows.

- A `search` parameter on inquirer.List can be set to True (False by default) so the user can see its current typed selection ( which is displayed using the already existing `get_current_value` method).

```python
inquirer.List("menu", message="Select an option",choices=choices, search=True)
```

![Screenshot from 2024-02-02 15-16-26](https://github.com/magmax/python-inquirer/assets/31577231/297fc5db-6f02-4052-97e5-d380fd53a30b)

I hope this is clean enough.

I though the user should always be able to select an entry by typing it. I could not think of a case in which that would be unwanted, so that's why the "select by typing" feature still works with `search=False`.