### PR TITLE
skip `get_hint` if no hints are defined

### DIFF
--- a/src/inquirer/questions.py
+++ b/src/inquirer/questions.py
@@ -60,7 +60,7 @@ class Question:
         self._validate = validate
         self.answers = {}
         self.show_default = show_default
-        self.hints = hints or {}
+        self.hints = hints
         self._other = other
 
         if self._other:

--- a/src/inquirer/render/console/__init__.py
+++ b/src/inquirer/render/console/__init__.py
@@ -93,7 +93,9 @@ class ConsoleRender:
 
     def _print_hint(self, render):
         msg_template = "{t.move_up}{t.clear_eol}{color}{msg}"
-        hint = render.get_hint()
+        hint = ""
+        if render.question.hints is not None:
+            hint = render.get_hint()
         color = self._theme.Question.mark_color
         if hint:
             self.print_str(

--- a/tests/integration/console_render/test_list.py
+++ b/tests/integration/console_render/test_list.py
@@ -165,3 +165,19 @@ class ListRenderTest(unittest.TestCase, helper.BaseTestCase):
         sut.render(question)
 
         self.assertInStdout("Bar")
+
+    def test_taggedValue_with_dict(self):
+        stdin = helper.event_factory(key.DOWN, key.ENTER)
+        message = "Foo message"
+        variable = "Bar variable"
+        choices = [
+            ("aa", {"a": 1}),
+            ("bb", {"b": 2}),
+        ]
+
+        question = questions.List(variable, message, choices=choices)
+
+        sut = ConsoleRender(event_generator=stdin)
+        sut.render(question)
+
+        self.assertInStdout("bb")


### PR DESCRIPTION
this ensures the code is skipped when not needed.
Also helps with non-hashable stuff being passed in.

fixes #525