### PR TITLE
Allow up-down moves within lists using CTRL+P/N

### DIFF
--- a/src/inquirer/render/console/_list.py
+++ b/src/inquirer/render/console/_list.py
@@ -66,13 +66,13 @@ class List(BaseConsoleRender):
 
     def process_input(self, pressed):
         question = self.question
-        if pressed == key.UP:
+        if pressed in (key.UP, key.CTRL_P):
             if question.carousel and self.current == 0:
                 self.current = len(question.choices) - 1
             else:
                 self.current = max(0, self.current - 1)
             return
-        if pressed == key.DOWN:
+        if pressed in (key.DOWN, key.CTRL_N):
             if question.carousel and self.current == len(question.choices) - 1:
                 self.current = 0
             else:

--- a/tests/integration/console_render/test_list.py
+++ b/tests/integration/console_render/test_list.py
@@ -94,6 +94,32 @@ class ListRenderTest(unittest.TestCase, helper.BaseTestCase):
 
         assert result == "foo"
 
+    def test_move_up_alt_keys(self):
+        stdin = helper.event_factory(key.DOWN, key.CTRL_P, key.ENTER)
+        message = "Foo message"
+        variable = "Bar variable"
+        choices = ["foo", "bar", "bazz"]
+
+        question = questions.List(variable, message, choices=choices)
+
+        sut = ConsoleRender(event_generator=stdin)
+        result = sut.render(question)
+
+        assert result == "foo"
+
+    def test_move_down_alt_keys(self):
+        stdin = helper.event_factory(key.CTRL_N, key.UP, key.ENTER)
+        message = "Foo message"
+        variable = "Bar variable"
+        choices = ["foo", "bar", "bazz"]
+
+        question = questions.List(variable, message, choices=choices)
+
+        sut = ConsoleRender(event_generator=stdin)
+        result = sut.render(question)
+
+        assert result == "foo"
+
     def test_move_down_carousel(self):
         stdin = helper.event_factory(key.DOWN, key.DOWN, key.DOWN, key.DOWN, key.ENTER)
         message = "Foo message"


### PR DESCRIPTION
Hi there :wave: 

Title is pretty self explanatory. CTRL-P/N is quite ubiquitous on any sort of terminal application, and just more comfortable to use without leaving the home row on the keyboard.