### PR TITLE
fix: respect symbol length

### DIFF
--- a/src/inquirer/render/console/_list.py
+++ b/src/inquirer/render/console/_list.py
@@ -61,7 +61,7 @@ class List(BaseConsoleRender):
                 symbol = "+" if choice == GLOBAL_OTHER_CHOICE else self.theme.List.selection_cursor
             else:
                 color = self.theme.List.unselected_color
-                symbol = " "
+                symbol = " " if choice == GLOBAL_OTHER_CHOICE else " " * len(self.theme.List.selection_cursor)
             yield choice, symbol, color
 
     def process_input(self, pressed):


### PR DESCRIPTION
If a symbol is more than one character, the rest of the choices still appear with a single indent, which moves choices around when changing choices.