### PR TITLE
Upgrade GitHub Actions Artifacts to v4 & Update Poetry Lockfile

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -42,7 +42,7 @@ jobs:
         run: nox --force-color --session=docs-build
 
       - name: Upload documentation
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docs
           path: docs/_build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,7 +78,7 @@ jobs:
           print("::set-output result={}".format(result))
 
       - name: Restore pre-commit cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         if: matrix.session == 'pre-commit'
         with:
           path: ~/.cache/pre-commit
@@ -92,10 +92,11 @@ jobs:
 
       - name: Upload coverage data
         if: always() && matrix.session == 'tests'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: coverage-data
+          name: coverage-data-${{ strategy.job-index }}
           path: ".coverage.*"
+          include-hidden-files: true
 
   coverage:
     runs-on: ubuntu-latest
@@ -126,9 +127,10 @@ jobs:
           nox --version
 
       - name: Download coverage data
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: coverage-data
+          pattern: coverage-data-*
+          merge-multiple: true
 
       - name: Combine coverage data and display human readable report
         run: |


### PR DESCRIPTION
This patch fixes GitHub actions for me. I upgraded them to v4 and made few tweaks to keep everything working. I passed the safety tests by updating the `poetry.lock` file. Please tell me if this is acceptable or if anything else needs adjusting.